### PR TITLE
85757936. Formatting & usability issues with Limesurvey date

### DIFF
--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -1290,17 +1290,162 @@ function do_date($ia)
         $goodchars = "0123456789".substr($goodchars,0,1);
         // "+1" makes room for a trailing space in date/time values
         $iLength=strlen($dateformatdetails['dateformat'])+1;
-
+        $mindate = new DateTime();
+        $mindate = $mindate->modify('-100 year')->format('Y');
+        $maxdate = new DateTime();
+        $maxdate = $maxdate->format('Y');
 
         // HTML for date question using datepicker
-        $answer="<p class='question answer-item text-item date-item'><label for='answer{$ia[1]}' class='hide label'>{$clang->gT('Date picker')}</label>
-        <input class='popupdate' type=\"text\" size=\"{$iLength}\" name=\"{$ia[1]}\" title='".sprintf($clang->gT('Format: %s'),$dateformatdetails['dateformat'])."' id=\"answer{$ia[1]}\" value=\"$dateoutput\" maxlength=\"{$iLength}\" onkeypress=\"return goodchars(event,'".$goodchars."')\" onchange=\"$checkconditionFunction(this.value, this.name, this.type)\" />
+        $answer="
+    <p class='question answer-item text-item date-item {$ia[1]}'>
+        <label for='answer{$ia[1]}' class='hide label'>{$clang->gT('Date picker')}</label>
+        <span class=\"full-date\"><input class='popupdate' type=\"text\" size=\"{$iLength}\" name=\"{$ia[1]}\" title='".sprintf($clang->gT('Format: %s'),$dateformatdetails['dateformat'])."' id=\"answer{$ia[1]}\" value=\"$dateoutput\" maxlength=\"{$iLength}\" onkeypress=\"return goodchars(event,'".$goodchars."')\" onchange=\"$checkconditionFunction(this.value, this.name, this.type)\" />
         <input  type='hidden' name='dateformat{$ia[1]}' id='dateformat{$ia[1]}' value='{$dateformatdetails['jsdate']}'  />
         <input  type='hidden' name='datelanguage{$ia[1]}' id='datelanguage{$ia[1]}' value='{$clang->langcode}'  />
         <input  type='hidden' name='datemin{$ia[1]}' id='datemin{$ia[1]}' value=\"{$mindate}\"    />
-        <input  type='hidden' name='datemax{$ia[1]}' id='datemax{$ia[1]}' value=\"{$maxdate}\"   />
-        </p>";
+        <input  type='hidden' name='datemax{$ia[1]}' id='datemax{$ia[1]}' value=\"{$maxdate}\"   /></span>
+        <span class=\"mobile-date\">
+        <span class=\"delete_date\">
+            <span id=\"span-year\">
+                <select class=\"dateSelect\" id=\"s-year\">
+                    <option disabled selected value=\"default\">Year</option>
+                    <script>
+                        var objDate = new Date();
+                        var thisYear = objDate.getFullYear();
+                        var year = [];
+                        for(var i = thisYear-100; i <=thisYear; i++){
+                            year.push('<option value='+i+'>'+i+'</option>');
+                        }
+                        $('p.{$ia[1]}').find('#span-year').children('select').append(year);
+                    </script>
+                </select>
+            </span>
+            <span id=\"span-month\" >
+                <select class=\"dateSelect\" id=\"s-month\">
+                    <option disabled selected value=\"default\">Month</option>
+                    <script>
+                        var month = [];
+                        for(var i = 1; i <=9; i++){
+                            month.push('<option value=0'+i+'>0'+i+'</option>');
+                        }
+                        for(var i = 10; i <=12; i++){
+                            month.push('<option value='+i+'>'+i+'</option>');
+                        }
+                        $('p.{$ia[1]}').find('#span-month').children('select').append(month);
+                    </script>
+                </select>
+            </span>
+            <span id=\"span-day\">
+                <select class=\"dateSelect\" id=\"s-day\">
+                    <option disabled selected value=\"default\">Day</option>
+                    <script>
+                        var days = []
+                        for(var i = 1; i <=9; i++){
+                            days.push('<option value=0'+i+'>0'+i+'</option>');
+                        }
+                        for(var i = 10; i <=31; i++){
+                            days.push('<option value='+i+'>'+i+'</option>');
+                        }
+                        $('p.{$ia[1]}').find('#span-day').children('select').append(days);
+                    </script>
+                </select>
+            </span>
+        </span>
 
+        <input class=\"hidInput\" type='hidden' name=\"{$ia[1]}\" id=\"answer{$ia[1]}\" value=\"$dateoutput\" ><span id=\"bDate{$ia[1]}\" class=\"b-Date\"></span>
+        </span>
+        <div class=\"errormassage\" style=\"color: #ff0f0f; font-size: 95%; font-weight: 700; margin-top:10px\"></div>
+    </p>
+    <script>
+        var parentP = $('.{$ia[1]}'),
+            dateFormat = '{$dateformatdetails['dateformat']}';
+        var spans = ['<span class=\"s-year\">YYYY</span>', '<span class=\"s-month\">MM</span>', '<span class=\"s-day\">DD</span>']
+        var sYear = parentP.find('.delete_date').children('#span-year').html(),
+            sMonth = parentP.find('.delete_date').children('#span-month').html(),
+            sDay = parentP.find('.delete_date').children('#span-day').html();
+        var regexp = /(y|m|d)+(-|\.|\/)(y|m|d)+(-|\.|\/)(y|m|d)+/;
+
+        var found = dateFormat.match(regexp);
+        var foundFormat = found[1]+found[3]+found[5];
+
+      parentP.find('.delete_date').empty();
+
+        switch(foundFormat){
+            case 'ymd':
+                parentP.find('.delete_date').append(sYear+sMonth+sDay);
+                $('#bDate{$ia[1]}').append(spans[0]+found[2]+spans[1]+found[2]+spans[2]);
+                break;
+            case 'mdy':
+                parentP.find('.delete_date').append(sMonth+sDay+sYear);
+                $('#bDate{$ia[1]}').append(spans[1]+found[2]+spans[2]+found[2]+spans[0]);
+                break;
+            case 'dmy':
+                parentP.find('.delete_date').append(sDay+sMonth+sYear);
+                $('#bDate{$ia[1]}').append(spans[2]+found[2]+spans[1]+found[2]+spans[0]);
+                break;
+
+        }
+        var dateoutput = '{$dateoutput}';
+        if (dateoutput){
+         var dbRegexp = /(\d*)(.)(\d*)(.)(\d*)/;
+         var dbFound = dateoutput.match(dbRegexp);
+         var dbFoundFormat = dbFound[1]+dbFound[3]+dbFound[5];
+             parentP.find('.b-Date').find('span').eq(0).text(dbFound[1]);
+             parentP.find('.b-Date').find('span').eq(1).text(dbFound[3]);
+             parentP.find('.b-Date').find('span').eq(2).text(dbFound[5]);
+             parentP.find('select').eq(0).val(dbFound[1]);
+             parentP.find('select').eq(1).val(dbFound[3]);
+             parentP.find('select').eq(2).val(dbFound[5]);
+        };
+        $('.{$ia[1]}').find('.dateSelect').on('change', function()\{
+            var sClass = $(this).attr('id');
+            var sHtml = $(this).val();
+            $('#bDate{$ia[1]}  > span.'+sClass).html(sHtml);
+           // $('input#answer{$ia[1]}').val($('#bDate{$ia[1]} ').text()+'-'+$('#bDate{$ia[1]} .s-month').text()+'-'+$('#bDate{$ia[1]} .s-day').text());
+            $('input#answer{$ia[1]}').val($('#bDate{$ia[1]} ').text());
+        \});
+
+        $(document).on('click', '#limesurvey #movesubmitbtn, #limesurvey #movenextbtn', function(e)\{
+
+            var spanYear, spanMonth, spanDay;
+            spanYear = +($('#bDate{$ia[1]}').find('.s-year').text());
+            spanMonth = +($('#bDate{$ia[1]}').find('.s-month').text());
+            spanDay = +($('#bDate{$ia[1]}').find('.s-day').text());
+            $(this).removeClass('active');
+            $('.button.ui-button' ).not($(this)).button( 'option', 'disabled', false );
+
+            if (!isNaN(spanYear) || !isNaN(spanMonth) || !isNaN(spanDay) )\{
+
+                var sError = [];
+                if(isNaN(spanYear))\{
+                    sError.push('Please select year. </br>');
+                \}
+                if(isNaN(spanMonth))\{
+                    sError.push('Please select month. </br>');
+                \}
+                if(isNaN(spanDay))\{
+                    sError.push('Please select day. </br>');
+                \}
+                if(sError.length != 0)\{
+                     $('.{$ia[1]}').siblings('.errormassage').html(sError).show('slow');
+
+                     $('#question{$ia[0]}').addClass('input-error');
+                     errorNotification($('#question{$ia[0]}'));
+                     $('#question{$ia[0]} .errormandatory').parent('strong').remove();
+                    return false;
+                    e.preventDefault();
+                \}else \{
+                    $('#question{$ia[0]} .errormandatory').parent('strong').remove();
+                    $('.{$ia[1]}').siblings('.errormassage').html('');
+                    return;
+                \}
+            \}
+            $('.{$ia[1]}').siblings('.errormassage').html('');
+
+            return;
+         \});
+    </script>
+";
         // adds min and max date as a hidden element to the page so EM creates the needed LEM_tailor_Q_XX sections 
         $sHiddenHtml="";
         if (!empty($sMindatetailor))

--- a/application/helpers/surveytranslator_helper.php
+++ b/application/helpers/surveytranslator_helper.php
@@ -1,710 +1,707 @@
 <?php
-    if ( ! defined('BASEPATH')) exit('No direct script access allowed');
-    /*
-    * LimeSurvey
-    * Copyright (C) 2007-2011 The LimeSurvey Project Team / Carsten Schmitz
-    * All rights reserved.
-    * License: GNU/GPL License v2 or later, see LICENSE.php
-    * LimeSurvey is free software. This version may have been modified pursuant
-    * to the GNU General Public License, and as distributed it includes or
-    * is derivative of works licensed under the GNU General Public License or
-    * other free or open source software licenses.
-    * See COPYRIGHT.php for copyright notices and details.
-    *
-       */
+if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+/*
+* LimeSurvey
+* Copyright (C) 2007-2011 The LimeSurvey Project Team / Carsten Schmitz
+* All rights reserved.
+* License: GNU/GPL License v2 or later, see LICENSE.php
+* LimeSurvey is free software. This version may have been modified pursuant
+* to the GNU General Public License, and as distributed it includes or
+* is derivative of works licensed under the GNU General Public License or
+* other free or open source software licenses.
+* See COPYRIGHT.php for copyright notices and details.
+*
+   */
 
 
-    /*
-    * Internationalization and Localization utilities
-    *
-    * @package LimeSurvey
-    * @subpackage Helpers
-    */
+/*
+* Internationalization and Localization utilities
+*
+* @package LimeSurvey
+* @subpackage Helpers
+*/
 
 
-    /**
-    * Returns all available dateformats in a structured aray
-    * If $iDateFormat is given only the particual dateformat will be returned
-    *
-    * @param $iDateFormat integer
-    * @param $sLanguageCode string
-    * @returns array
-    *
-    */
-    function getDateFormatData($iDateFormat=0,$sLanguageCode='en')
-    {
-        $clang = new Limesurvey_lang($sLanguageCode);
-        $aDateFormats= array(
+/**
+ * Returns all available dateformats in a structured aray
+ * If $iDateFormat is given only the particual dateformat will be returned
+ *
+ * @param $iDateFormat integer
+ * @param $sLanguageCode string
+ * @returns array
+ *
+ */
+function getDateFormatData($iDateFormat=0,$sLanguageCode='en')
+{
+    $clang = new Limesurvey_lang($sLanguageCode);
+    $aDateFormats= array(
         1=> array ('phpdate' => 'd.m.Y', 'jsdate' => 'dd.mm.yy', 'dateformat' => $clang->gT('dd.mm.yyyy')),
         2=> array ('phpdate' => 'd-m-Y', 'jsdate' => 'dd-mm-yy', 'dateformat' => $clang->gT('dd-mm-yyyy')),
         3=> array ('phpdate' => 'Y.m.d', 'jsdate' => 'yy.mm.dd', 'dateformat' => $clang->gT('yyyy.mm.dd')),
-        4=> array ('phpdate' => 'j.n.Y', 'jsdate' => 'd.m.yy',   'dateformat' => $clang->gT('d.m.yyyy')),
         5=> array ('phpdate' => 'd/m/Y', 'jsdate' => 'dd/mm/yy', 'dateformat' => $clang->gT('dd/mm/yyyy')),
         6=> array ('phpdate' => 'Y-m-d', 'jsdate' => 'yy-mm-dd', 'dateformat' => $clang->gT('yyyy-mm-dd')),
         7=> array ('phpdate' => 'Y/m/d', 'jsdate' => 'yy/mm/dd', 'dateformat' => $clang->gT('yyyy/mm/dd')),
-        8=> array ('phpdate' => 'j/n/Y', 'jsdate' => 'd/m/yy',   'dateformat' => $clang->gT('d/m/yyyy')),
         9=> array ('phpdate' => 'm-d-Y', 'jsdate' => 'mm-dd-yy', 'dateformat' => $clang->gT('mm-dd-yyyy')),
         10=>array ('phpdate' => 'm.d.Y', 'jsdate' => 'mm.dd.yy', 'dateformat' => $clang->gT('mm.dd.yyyy')),
         11=>array ('phpdate' => 'm/d/Y', 'jsdate' => 'mm/dd/yy', 'dateformat' => $clang->gT('mm/dd/yyyy')),
-        12=>array ('phpdate' => 'j-n-Y', 'jsdate' => 'd-m-yy',   'dateformat' => $clang->gT('d-m-yyyy'))
-        );
+    );
 
-        if ($iDateFormat > 12 || $iDateFormat<0) {
-            $iDateFormat = 11;   // TODO - what should default be?
-        }
-        if ($iDateFormat >0)
-        {
-            return $aDateFormats[$iDateFormat];
-        }
-        else
-            return $aDateFormats;
-
+    if ($iDateFormat > 12 || $iDateFormat<0) {
+        $iDateFormat = 11;   // TODO - what should default be?
     }
-
-    function getLanguageData($bOrderByNative=false,$sLanguageCode='en') {
-
-        $clang = new Limesurvey_lang($sLanguageCode);
-
-        static $result = array();
-
-        if (isset($result[$sLanguageCode][$bOrderByNative])) return $result[$sLanguageCode][$bOrderByNative];
-
-        // Afrikaans
-        $supportedLanguages['af']['description'] = $clang->gT('Afrikaans');
-        $supportedLanguages['af']['nativedescription'] = 'Afrikaans';
-        $supportedLanguages['af']['rtl'] = false;
-        $supportedLanguages['af']['dateformat'] = 1;
-        $supportedLanguages['af']['radixpoint'] = 1;
-
-        // Albanian
-        $supportedLanguages['sq']['description'] = $clang->gT('Albanian');
-        $supportedLanguages['sq']['nativedescription'] = 'Shqipe';
-        $supportedLanguages['sq']['rtl'] = false;
-        $supportedLanguages['sq']['dateformat'] = 1;
-        $supportedLanguages['sq']['radixpoint'] = 1;
-
-        // Amharic
-        $supportedLanguages['am']['description'] = $clang->gT('Amharic');
-        $supportedLanguages['am']['nativedescription'] = '&#4768;&#4635;&#4653;&#4763;';
-        $supportedLanguages['am']['rtl'] = false;
-        $supportedLanguages['am']['dateformat'] = 2;
-        $supportedLanguages['am']['radixpoint'] = 1;
-
-        // Arabic
-        $supportedLanguages['ar']['description'] = $clang->gT('Arabic');
-        $supportedLanguages['ar']['nativedescription'] = '&#1593;&#1614;&#1585;&#1614;&#1576;&#1610;&#1618;';
-        $supportedLanguages['ar']['rtl'] = true;
-        $supportedLanguages['ar']['dateformat'] = 2;
-        $supportedLanguages['ar']['radixpoint'] = 0;
-
-        // Armenian
-        $supportedLanguages['hy']['description'] = $clang->gT('Armenian');
-        $supportedLanguages['hy']['nativedescription'] = '&#1392;&#1377;&#1397;&#1381;&#1408;&#1381;&#1398;';
-        $supportedLanguages['hy']['rtl'] = false;
-        $supportedLanguages['hy']['dateformat'] = 1;
-        $supportedLanguages['hy']['radixpoint'] = 1;
-
-        // Basque
-        $supportedLanguages['eu']['description'] = $clang->gT('Basque');
-        $supportedLanguages['eu']['nativedescription'] = 'Euskara';
-        $supportedLanguages['eu']['rtl'] = false;
-        $supportedLanguages['eu']['dateformat'] = 3;
-        $supportedLanguages['eu']['radixpoint'] = 1;
-
-        // Belarusian
-        $supportedLanguages['be']['description'] = $clang->gT('Belarusian');
-        $supportedLanguages['be']['nativedescription'] = '&#1041;&#1077;&#1083;&#1072;&#1088;&#1091;&#1089;&#1082;&#1110;';
-        $supportedLanguages['be']['rtl'] = false;
-        $supportedLanguages['be']['dateformat'] = 1;
-        $supportedLanguages['be']['radixpoint'] = 1;
-
-        // Bosnian
-        $supportedLanguages['bs']['description'] = $clang->gT('Bosnian');
-        $supportedLanguages['bs']['nativedescription'] = 'Bosanski';
-        $supportedLanguages['bs']['rtl'] = false;
-        $supportedLanguages['bs']['dateformat'] = 4;
-        $supportedLanguages['bs']['radixpoint'] = 0;
-
-        // Bulgarian
-        $supportedLanguages['bg']['description'] = $clang->gT('Bulgarian');
-        $supportedLanguages['bg']['nativedescription'] = '&#x0411;&#x044a;&#x043b;&#x0433;&#x0430;&#x0440;&#x0441;&#x043a;&#x0438;';
-        $supportedLanguages['bg']['rtl'] = false;
-        $supportedLanguages['bg']['dateformat'] = 1;
-        $supportedLanguages['bg']['radixpoint'] = 0;
-
-        // Catalan
-        $supportedLanguages['ca-valencia']['description'] = $clang->gT('Catalan (Valencian)');
-        $supportedLanguages['ca-valencia']['nativedescription'] = 'Catal&#224; (Valenci&#224;)';
-        $supportedLanguages['ca-valencia']['rtl'] = false;
-        $supportedLanguages['ca-valencia']['dateformat'] = 1;
-        $supportedLanguages['ca-valencia']['radixpoint'] = 1;
-
-        // Catalan
-        $supportedLanguages['ca']['description'] = $clang->gT('Catalan');
-        $supportedLanguages['ca']['nativedescription'] = 'Catal&#224;';
-        $supportedLanguages['ca']['rtl'] = false;
-        $supportedLanguages['ca']['dateformat'] = 1;
-        $supportedLanguages['ca']['radixpoint'] = 1;
-
-        // Welsh
-        $supportedLanguages['cy']['description'] = $clang->gT('Welsh');
-        $supportedLanguages['cy']['nativedescription'] = 'Cymraeg';
-        $supportedLanguages['cy']['rtl'] = false;
-        $supportedLanguages['cy']['dateformat'] = 5;
-        $supportedLanguages['cy']['radixpoint'] = 0;
-
-        // Chinese (Simplified)
-        $supportedLanguages['zh-Hans']['description'] = $clang->gT('Chinese (Simplified)');
-        $supportedLanguages['zh-Hans']['nativedescription'] = '&#31616;&#20307;&#20013;&#25991;';
-        $supportedLanguages['zh-Hans']['rtl'] = false;
-        $supportedLanguages['zh-Hans']['dateformat'] = 6;
-        $supportedLanguages['zh-Hans']['radixpoint'] = 0;
-
-        // Chinese (Traditional - Hong Kong)
-        $supportedLanguages['zh-Hant-HK']['description'] = $clang->gT('Chinese (Traditional - Hong Kong)');
-        $supportedLanguages['zh-Hant-HK']['nativedescription'] = '&#32321;&#39636;&#20013;&#25991;&#35486;&#31995;';
-        $supportedLanguages['zh-Hant-HK']['rtl'] = false;
-        $supportedLanguages['zh-Hant-HK']['dateformat'] = 6;
-        $supportedLanguages['zh-Hant-HK']['radixpoint'] = 0;
-
-        // Chinese (Traditional - Taiwan)
-        $supportedLanguages['zh-Hant-TW']['description'] = $clang->gT('Chinese (Traditional - Taiwan)');
-        $supportedLanguages['zh-Hant-TW']['nativedescription'] = '&#32321;&#39636;&#20013;&#25991;&#65288;&#21488;&#28771;&#65289;';
-        $supportedLanguages['zh-Hant-TW']['rtl'] = false;
-        $supportedLanguages['zh-Hant-TW']['dateformat'] = 6;
-        $supportedLanguages['zh-Hant-TW']['radixpoint'] = 0;
-
-        // Croatian
-        $supportedLanguages['hr']['description'] = $clang->gT('Croatian');
-        $supportedLanguages['hr']['nativedescription'] = 'Hrvatski';
-        $supportedLanguages['hr']['rtl'] = false;
-        $supportedLanguages['hr']['dateformat'] = 4;
-        $supportedLanguages['hr']['radixpoint'] = 1;
-
-        // Czech
-        $supportedLanguages['cs']['description'] = $clang->gT('Czech');
-        $supportedLanguages['cs']['nativedescription'] = '&#x010c;esky';
-        $supportedLanguages['cs']['rtl'] = false;
-        $supportedLanguages['cs']['dateformat'] = 4;
-        $supportedLanguages['cs']['radixpoint'] = 1;
-
-        // Czech informal
-        $supportedLanguages['cs-informal']['description'] = $clang->gT('Czech (informal)');
-        $supportedLanguages['cs-informal']['nativedescription'] = '&#x010c;esky neform&aacute;ln&iacute;';
-        $supportedLanguages['cs-informal']['rtl'] = false;
-        $supportedLanguages['cs-informal']['dateformat'] = 4;
-        $supportedLanguages['cs-informal']['radixpoint'] = 1;
-        
-        
-        // Danish
-        $supportedLanguages['da']['description'] = $clang->gT('Danish');
-        $supportedLanguages['da']['nativedescription'] = 'Dansk';
-        $supportedLanguages['da']['rtl'] = false;
-        $supportedLanguages['da']['dateformat'] =  2;
-        $supportedLanguages['da']['radixpoint'] = 1;
-
-        // Dari
-        $supportedLanguages['prs']['description'] = $clang->gT('Dari');
-        $supportedLanguages['prs']['nativedescription'] = '&#1583;&#1585;&#1740;';
-        $supportedLanguages['prs']['rtl'] = true;
-        $supportedLanguages['prs']['dateformat'] = 6;
-        $supportedLanguages['prs']['radixpoint'] = 0;
-
-        // Dutch
-        $supportedLanguages['nl']['description'] = $clang->gT('Dutch');
-        $supportedLanguages['nl']['nativedescription'] = 'Nederlands';
-        $supportedLanguages['nl']['rtl'] = false;
-        $supportedLanguages['nl']['dateformat'] = 2;
-        $supportedLanguages['nl']['radixpoint'] = 1;
-
-        // Dutch
-        $supportedLanguages['nl-informal']['description'] = $clang->gT('Dutch (informal)');
-        $supportedLanguages['nl-informal']['nativedescription'] = 'Nederlands (informeel)';
-        $supportedLanguages['nl-informal']['rtl'] = false;
-        $supportedLanguages['nl-informal']['dateformat'] = 2;
-        $supportedLanguages['nl-informal']['radixpoint'] = 1;
-
-        // English
-        $supportedLanguages['en']['description'] = $clang->gT('English');
-        $supportedLanguages['en']['nativedescription'] = 'English';
-        $supportedLanguages['en']['rtl'] = false;
-        $supportedLanguages['en']['dateformat'] = 9;
-        $supportedLanguages['en']['radixpoint'] = 0;
-
-        // Estonian
-        $supportedLanguages['et']['description'] = $clang->gT('Estonian');
-        $supportedLanguages['et']['nativedescription'] = 'Eesti';
-        $supportedLanguages['et']['rtl'] = false;
-        $supportedLanguages['et']['dateformat'] = 4;
-        $supportedLanguages['et']['radixpoint'] = 1;
-
-        // Finnish
-        $supportedLanguages['fi']['description'] = $clang->gT('Finnish');
-        $supportedLanguages['fi']['nativedescription'] = 'Suomi';
-        $supportedLanguages['fi']['rtl'] = false;
-        $supportedLanguages['fi']['dateformat'] = 4;
-        $supportedLanguages['fi']['radixpoint'] = 1;
-
-        // French
-        $supportedLanguages['fr']['description'] = $clang->gT('French');
-        $supportedLanguages['fr']['nativedescription'] = 'Fran&#231;ais';
-        $supportedLanguages['fr']['rtl'] = false;
-        $supportedLanguages['fr']['dateformat'] = 5;
-        $supportedLanguages['fr']['radixpoint'] = 1;
-
-        // Fula
-        $supportedLanguages['ful']['description'] = $clang->gT('Fula');
-        $supportedLanguages['ful']['nativedescription'] = 'Fulfulde';
-        $supportedLanguages['ful']['rtl'] = false;
-        $supportedLanguages['ful']['dateformat'] = 5;
-        $supportedLanguages['ful']['radixpoint'] = 1;
-
-        // Galician
-        $supportedLanguages['gl']['description'] = $clang->gT('Galician');
-        $supportedLanguages['gl']['nativedescription'] = 'Galego';
-        $supportedLanguages['gl']['rtl'] = false;
-        $supportedLanguages['gl']['dateformat'] = 5;
-        $supportedLanguages['gl']['radixpoint'] = 1;
-
-        // Georgian
-        $supportedLanguages['ka']['description'] = $clang->gT('Georgian');
-        $supportedLanguages['ka']['nativedescription'] = '&#4325;&#4304;&#4320;&#4311;&#4323;&#4314;&#4312; &#4308;&#4316;&#4304;';
-        $supportedLanguages['ka']['rtl'] = false;
-        $supportedLanguages['ka']['dateformat'] = 1;
-        $supportedLanguages['ka']['radixpoint'] = 1;
-
-        // German
-        $supportedLanguages['de']['description'] = $clang->gT('German');
-        $supportedLanguages['de']['nativedescription'] = 'Deutsch';
-        $supportedLanguages['de']['rtl'] = false;
-        $supportedLanguages['de']['dateformat'] = 1;
-        $supportedLanguages['de']['radixpoint'] = 1;
-
-        // German informal
-        $supportedLanguages['de-informal']['description'] = $clang->gT('German (informal)');
-        $supportedLanguages['de-informal']['nativedescription'] = 'Deutsch (Du)';
-        $supportedLanguages['de-informal']['rtl'] = false;
-        $supportedLanguages['de-informal']['dateformat'] = 1;
-        $supportedLanguages['de-informal']['radixpoint'] = 1;
-        
-        // Gujarati
-        $supportedLanguages['gu']['description'] = $clang->gT('Gujarati');
-        $supportedLanguages['gu']['nativedescription'] = '&#2711;&#2753;&#2716;&#2736;&#2750;&#2724;&#2752;';
-        $supportedLanguages['gu']['rtl'] = false;
-        $supportedLanguages['gu']['dateformat'] = 2;
-        $supportedLanguages['gu']['radixpoint'] = 0;
-
-        // Greek
-        $supportedLanguages['el']['description'] = $clang->gT('Greek');
-        $supportedLanguages['el']['nativedescription'] = '&#949;&#955;&#955;&#951;&#957;&#953;&#954;&#940;';
-        $supportedLanguages['el']['rtl'] = false;
-        $supportedLanguages['el']['dateformat'] = 8;
-        $supportedLanguages['el']['radixpoint'] = 1;
-
-        // Hindi
-        $supportedLanguages['hi']['description'] = $clang->gT('Hindi');
-        $supportedLanguages['hi']['nativedescription'] = '&#2361;&#2367;&#2344;&#2381;&#2342;&#2368;';
-        $supportedLanguages['hi']['rtl'] = false;
-        $supportedLanguages['hi']['dateformat'] = 2;
-        $supportedLanguages['hi']['radixpoint'] = 0;
-
-        // Hebrew
-        $supportedLanguages['he']['description'] = $clang->gT('Hebrew');
-        $supportedLanguages['he']['nativedescription'] = ' &#1506;&#1489;&#1512;&#1497;&#1514;';
-        $supportedLanguages['he']['rtl'] = true;
-        $supportedLanguages['he']['dateformat'] = 5;
-        $supportedLanguages['he']['radixpoint'] = 0;
-
-        // Hungarian
-        $supportedLanguages['hu']['description'] = $clang->gT('Hungarian');
-        $supportedLanguages['hu']['nativedescription'] = 'Magyar';
-        $supportedLanguages['hu']['rtl'] = false;
-        $supportedLanguages['hu']['dateformat'] = 6;
-        $supportedLanguages['hu']['radixpoint'] = 1;
-
-        // Icelandic
-        $supportedLanguages['is']['description'] = $clang->gT('Icelandic');
-        $supportedLanguages['is']['nativedescription'] = '&#237;slenska';
-        $supportedLanguages['is']['rtl'] = false;
-        $supportedLanguages['is']['dateformat'] = 1;
-        $supportedLanguages['is']['radixpoint'] = 1;
-
-        // Indonesian
-        $supportedLanguages['id']['description'] = $clang->gT('Indonesian');
-        $supportedLanguages['id']['nativedescription'] = 'Bahasa Indonesia';
-        $supportedLanguages['id']['rtl'] = false;
-        $supportedLanguages['id']['dateformat'] = 5;
-        $supportedLanguages['id']['radixpoint'] = 1;
-
-        // Irish
-        $supportedLanguages['ie']['description'] = $clang->gT('Irish');
-        $supportedLanguages['ie']['nativedescription'] = 'Gaeilge';
-        $supportedLanguages['ie']['rtl'] = false;
-        $supportedLanguages['ie']['dateformat'] = 2;
-        $supportedLanguages['ie']['radixpoint'] = 0;
-
-        // Italian
-        $supportedLanguages['it']['description'] = $clang->gT('Italian');
-        $supportedLanguages['it']['nativedescription'] = 'Italiano';
-        $supportedLanguages['it']['rtl'] = false;
-        $supportedLanguages['it']['dateformat'] = 5;
-        $supportedLanguages['it']['radixpoint'] = 1;
-
-        // Italian informal
-        $supportedLanguages['it-informal']['description'] = $clang->gT('Italian (informal)');
-        $supportedLanguages['it-informal']['nativedescription'] = 'Italiano (informale)';
-        $supportedLanguages['it-informal']['rtl'] = false;
-        $supportedLanguages['it-informal']['dateformat'] = 5;
-        $supportedLanguages['it-informal']['radixpoint'] = 1;
-
-        // Japanese
-        $supportedLanguages['ja']['description'] = $clang->gT('Japanese');
-        $supportedLanguages['ja']['nativedescription'] = '&#x65e5;&#x672c;&#x8a9e;';
-        $supportedLanguages['ja']['rtl'] = false;
-        $supportedLanguages['ja']['dateformat'] = 6;
-        $supportedLanguages['ja']['radixpoint'] = 0;
-
-        // Kinyarwanda 
-        $supportedLanguages['rw']['description'] = $clang->gT('Kinyarwanda');
-        $supportedLanguages['rw']['nativedescription'] = 'Kinyarwanda';
-        $supportedLanguages['rw']['rtl'] = false;
-        $supportedLanguages['rw']['dateformat'] = 5;
-        $supportedLanguages['rw']['radixpoint'] = 1;
-
-        // Korean
-        $supportedLanguages['ko']['description'] = $clang->gT('Korean');
-        $supportedLanguages['ko']['nativedescription'] = '&#54620;&#44397;&#50612;';
-        $supportedLanguages['ko']['rtl'] = false;
-        $supportedLanguages['ko']['dateformat'] = 7;
-        $supportedLanguages['ko']['radixpoint'] = 0;
-
-        // Kurdish (Sorani)
-        $supportedLanguages['ckb']['description'] = $clang->gT('Kurdish (Sorani)');
-        $supportedLanguages['ckb']['nativedescription'] = '&#1705;&#1608;&#1585;&#1583;&#1740;&#1740; &#1606;&#1575;&#1608;&#1749;&#1606;&#1583;&#1740;';
-        $supportedLanguages['ckb']['rtl'] = true;
-        $supportedLanguages['ckb']['dateformat'] = 1;
-        $supportedLanguages['ckb']['radixpoint'] = 1;
-        
-        
-        // Lithuanian
-        $supportedLanguages['lt']['description'] = $clang->gT('Lithuanian');
-        $supportedLanguages['lt']['nativedescription'] = 'Lietuvi&#371;';
-        $supportedLanguages['lt']['rtl'] = false;
-        $supportedLanguages['lt']['dateformat'] = 6;
-        $supportedLanguages['lt']['radixpoint'] = 1;
-
-        // Latvian
-        $supportedLanguages['lv']['description'] = $clang->gT('Latvian');
-        $supportedLanguages['lv']['nativedescription'] = 'Latvie&#353;u';
-        $supportedLanguages['lv']['rtl'] = false;
-        $supportedLanguages['lv']['dateformat'] = 6;
-        $supportedLanguages['lv']['radixpoint'] = 1;
-
-        // Macedonian
-        $supportedLanguages['mk']['description'] = $clang->gT('Macedonian');
-        $supportedLanguages['mk']['nativedescription'] = '&#1052;&#1072;&#1082;&#1077;&#1076;&#1086;&#1085;&#1089;&#1082;&#1080;';
-        $supportedLanguages['mk']['rtl'] = false;
-        $supportedLanguages['mk']['dateformat'] = 1;
-        $supportedLanguages['mk']['radixpoint'] = 1;
-
-        // Mongolian
-        $supportedLanguages['mn']['description'] = $clang->gT('Mongolian');
-        $supportedLanguages['mn']['nativedescription'] = '&#1052;&#1086;&#1085;&#1075;&#1086;&#1083;';
-        $supportedLanguages['mn']['rtl'] = false;
-        $supportedLanguages['mn']['dateformat'] = 3;
-        $supportedLanguages['mn']['radixpoint'] = 0;
-
-        // Malay
-        $supportedLanguages['ms']['description'] = $clang->gT('Malay');
-        $supportedLanguages['ms']['nativedescription'] = 'Bahasa Melayu';
-        $supportedLanguages['ms']['rtl'] = false;
-        $supportedLanguages['ms']['dateformat'] = 1;
-        $supportedLanguages['ms']['radixpoint'] = 0;
-
-        // Maltese
-        $supportedLanguages['mt']['description'] = $clang->gT('Maltese');
-        $supportedLanguages['mt']['nativedescription'] = 'Malti';
-        $supportedLanguages['mt']['rtl'] = false;
-        $supportedLanguages['mt']['dateformat'] = 1;
-        $supportedLanguages['mt']['radixpoint'] = 0;
-
-        // Marathi
-        $supportedLanguages['mr']['description'] = $clang->gT('Marathi');
-        $supportedLanguages['mr']['nativedescription'] = '&#2350;&#2352;&#2366;&#2336;&#2368;';
-        $supportedLanguages['mr']['rtl'] = false;
-        $supportedLanguages['mr']['dateformat'] = 2;
-        $supportedLanguages['mr']['radixpoint'] = 0;
-        
-        // Norwegian Bokmal
-        $supportedLanguages['nb']['description'] = $clang->gT('Norwegian (Bokmal)');
-        $supportedLanguages['nb']['nativedescription'] = 'Norsk Bokm&#229;l';
-        $supportedLanguages['nb']['rtl'] = false;
-        $supportedLanguages['nb']['dateformat'] = 4;
-        $supportedLanguages['nb']['radixpoint'] = 1;
-
-        // Norwegian Nynorsk
-        $supportedLanguages['nn']['description'] = $clang->gT('Norwegian (Nynorsk)');
-        $supportedLanguages['nn']['nativedescription'] = 'Norsk Nynorsk';
-        $supportedLanguages['nn']['rtl'] = false;
-        $supportedLanguages['nn']['dateformat'] = 4;
-        $supportedLanguages['nn']['radixpoint'] = 1;
-
-        // Occitan
-        $supportedLanguages['oc']['description'] = $clang->gT('Occitan');
-        $supportedLanguages['oc']['nativedescription'] = 'Lenga d&#39;&#242;c';
-        $supportedLanguages['oc']['rtl'] = false;
-        $supportedLanguages['oc']['dateformat'] = 5;
-        $supportedLanguages['oc']['radixpoint'] = 1;
-
-        // Pashto
-        $supportedLanguages['ps']['description'] = $clang->gT('Pashto');
-        $supportedLanguages['ps']['nativedescription'] = '&#1662;&#1690;&#1578;&#1608;';
-        $supportedLanguages['ps']['rtl'] = true;
-        $supportedLanguages['ps']['dateformat'] = 6;
-        $supportedLanguages['ps']['radixpoint'] = 0;
-
-        // Persian
-        $supportedLanguages['fa']['description'] = $clang->gT('Persian');
-        $supportedLanguages['fa']['nativedescription'] = '&#1601;&#1575;&#1585;&#1587;&#1740;';
-        $supportedLanguages['fa']['rtl'] = true;
-        $supportedLanguages['fa']['dateformat'] = 6;
-        $supportedLanguages['fa']['radixpoint'] = 0;
-
-        // Papiamento (Aruba)
-        $supportedLanguages['pap-AW']['description'] = $clang->gT('Papiamento (Aruba)');
-        $supportedLanguages['pap-AW']['nativedescription'] = 'Papiamento';
-        $supportedLanguages['pap-AW']['rtl'] = false;
-        $supportedLanguages['pap-AW']['dateformat'] = 2;
-        $supportedLanguages['pap-AW']['radixpoint'] = 1;
-
-        // Papiamento (Curaçao and Bonaire)
-        $supportedLanguages['pap-CW']['description'] = $clang->gT('Papiamento (Curaçao and Bonaire)');
-        $supportedLanguages['pap-CW']['nativedescription'] = 'Papiamentu';
-        $supportedLanguages['pap-CW']['rtl'] = false;
-        $supportedLanguages['pap-CW']['dateformat'] = 2;
-        $supportedLanguages['pap-CW']['radixpoint'] = 1;
-
-        // Polish
-        $supportedLanguages['pl']['description'] = $clang->gT('Polish');
-        $supportedLanguages['pl']['nativedescription'] = 'Polski';
-        $supportedLanguages['pl']['rtl'] = false;
-        $supportedLanguages['pl']['dateformat'] = 1;
-        $supportedLanguages['pl']['radixpoint'] = 1;
-
-        // Portuguese
-        $supportedLanguages['pt']['description'] = $clang->gT('Portuguese');
-        $supportedLanguages['pt']['nativedescription'] = 'Portugu&#234;s';
-        $supportedLanguages['pt']['rtl'] = false;
-        $supportedLanguages['pt']['dateformat'] = 5;
-        $supportedLanguages['pt']['radixpoint'] = 1;
-
-        // Brazilian Portuguese
-        $supportedLanguages['pt-BR']['description'] = $clang->gT('Portuguese (Brazilian)');
-        $supportedLanguages['pt-BR']['nativedescription'] = 'Portugu&#234;s do Brasil';
-        $supportedLanguages['pt-BR']['rtl'] = false;
-        $supportedLanguages['pt-BR']['dateformat'] = 5;
-        $supportedLanguages['pt-BR']['radixpoint'] = 1;
-
-        // Punjabi
-        $supportedLanguages['pa']['description'] = $clang->gT('Punjabi');
-        $supportedLanguages['pa']['nativedescription'] = '&#2602;&#2672;&#2588;&#2622;&#2604;&#2624;';
-        $supportedLanguages['pa']['rtl'] = false;
-        $supportedLanguages['pa']['dateformat'] = 2;
-        $supportedLanguages['pa']['radixpoint'] = 0;
-
-        // Russian
-        $supportedLanguages['ru']['description'] = $clang->gT('Russian');
-        $supportedLanguages['ru']['nativedescription'] = '&#1056;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;';
-        $supportedLanguages['ru']['rtl'] = false;
-        $supportedLanguages['ru']['dateformat'] = 1;
-        $supportedLanguages['ru']['radixpoint'] = 1;
-
-        // Romanian
-        $supportedLanguages['ro']['description'] = $clang->gT('Romanian');
-        $supportedLanguages['ro']['nativedescription'] = 'Rom&#226;na';
-        $supportedLanguages['ro']['rtl'] = false;
-        $supportedLanguages['ro']['dateformat'] = 1;
-        $supportedLanguages['ro']['radixpoint'] = 1;
-
-        // Slovak
-        $supportedLanguages['sk']['description'] = $clang->gT('Slovak');
-        $supportedLanguages['sk']['nativedescription'] = 'Sloven&#269;ina';
-        $supportedLanguages['sk']['rtl'] = false;
-        $supportedLanguages['sk']['dateformat'] = 4;
-        $supportedLanguages['sk']['radixpoint'] = 1;
-
-        // Sinhala
-        $supportedLanguages['si']['description'] = $clang->gT('Sinhala');
-        $supportedLanguages['si']['nativedescription'] = '&#3523;&#3538;&#3458;&#3524;&#3517;';
-        $supportedLanguages['si']['rtl'] = false;
-        $supportedLanguages['si']['dateformat'] = 5;
-        $supportedLanguages['si']['radixpoint'] = 0;
-
-        // Slovenian
-        $supportedLanguages['sl']['description'] = $clang->gT('Slovenian');
-        $supportedLanguages['sl']['nativedescription'] = 'Sloven&#353;&#269;ina';
-        $supportedLanguages['sl']['rtl'] = false;
-        $supportedLanguages['sl']['dateformat'] = 4;
-        $supportedLanguages['sl']['radixpoint'] = 1;
-
-        // Serbian
-        $supportedLanguages['sr']['description'] = $clang->gT('Serbian (Cyrillic)');
-        $supportedLanguages['sr']['nativedescription'] = '&#1057;&#1088;&#1087;&#1089;&#1082;&#1080;';
-        $supportedLanguages['sr']['rtl'] = false;
-        $supportedLanguages['sr']['dateformat'] = 4;
-        $supportedLanguages['sr']['radixpoint'] = 1;
-
-        // Serbian (Latin script)
-        $supportedLanguages['sr-Latn']['description'] = $clang->gT('Serbian (Latin)');
-        $supportedLanguages['sr-Latn']['nativedescription'] = 'Srpski';
-        $supportedLanguages['sr-Latn']['rtl'] = false;
-        $supportedLanguages['sr-Latn']['dateformat'] = 4;
-        $supportedLanguages['sr-Latn']['radixpoint'] = 1;
-        
-        // Spanish
-        $supportedLanguages['es']['description'] = $clang->gT('Spanish');
-        $supportedLanguages['es']['nativedescription'] = 'Espa&#241;ol';
-        $supportedLanguages['es']['rtl'] = false;
-        $supportedLanguages['es']['dateformat'] = 5;
-        $supportedLanguages['es']['radixpoint'] = 1;
-        
-        // Spanish (Argentina)
-        $supportedLanguages['es-AR']['description'] = $clang->gT('Spanish (Argentina)');
-        $supportedLanguages['es-AR']['nativedescription'] = 'Espa&#241;ol rioplatense';
-        $supportedLanguages['es-AR']['rtl'] = false;
-        $supportedLanguages['es-AR']['dateformat'] = 5;
-        $supportedLanguages['es-AR']['radixpoint'] = 0;
-
-        // Spanish (Argentina) (Informal)
-        $supportedLanguages['es-AR-informal']['description'] = $clang->gT('Spanish (Argentina) (Informal)');
-        $supportedLanguages['es-AR-informal']['nativedescription'] = 'Espa&#241;ol rioplatense informal';
-        $supportedLanguages['es-AR-informal']['rtl'] = false;
-        $supportedLanguages['es-AR-informal']['dateformat'] = 5;
-        $supportedLanguages['es-AR-informal']['radixpoint'] = 0;
-
-        // Spanish (Chile)
-        $supportedLanguages['es-CL']['description'] = $clang->gT('Spanish (Chile)');
-        $supportedLanguages['es-CL']['nativedescription'] = 'Espa&#241;ol chileno';
-        $supportedLanguages['es-CL']['rtl'] = false;
-        $supportedLanguages['es-CL']['dateformat'] = 5;
-        $supportedLanguages['es-CL']['radixpoint'] = 0;
-
-        // Spanish (Mexico)
-        $supportedLanguages['es-MX']['description'] = $clang->gT('Spanish (Mexico)');
-        $supportedLanguages['es-MX']['nativedescription'] = 'Espa&#241;ol mexicano';
-        $supportedLanguages['es-MX']['rtl'] = false;
-        $supportedLanguages['es-MX']['dateformat'] = 5;
-        $supportedLanguages['es-MX']['radixpoint'] = 0;
-
-        // Swahili
-        $supportedLanguages['swh']['description'] = $clang->gT('Swahili');
-        $supportedLanguages['swh']['nativedescription'] = 'Kiswahili';
-        $supportedLanguages['swh']['rtl'] = false;
-        $supportedLanguages['swh']['dateformat'] = 1;
-        $supportedLanguages['swh']['radixpoint'] = 1;
-
-        // Swedish
-        $supportedLanguages['sv']['description'] = $clang->gT('Swedish');
-        $supportedLanguages['sv']['nativedescription'] = 'Svenska';
-        $supportedLanguages['sv']['rtl'] = false;
-        $supportedLanguages['sv']['dateformat'] = 6;
-        $supportedLanguages['sv']['radixpoint'] = 1;
-
-        // Tamil
-        $supportedLanguages['ta']['description'] = $clang->gT('Tamil');
-        $supportedLanguages['ta']['nativedescription'] = '&#2980;&#2990;&#3007;&#2996;&#3021;';
-        $supportedLanguages['ta']['rtl'] = false;
-        $supportedLanguages['ta']['dateformat'] = 2;
-        $supportedLanguages['ta']['radixpoint'] = 0;
-
-        // Turkish
-        $supportedLanguages['tr']['description'] = $clang->gT('Turkish');
-        $supportedLanguages['tr']['nativedescription'] = 'T&#252;rk&#231;e';
-        $supportedLanguages['tr']['rtl'] = false;
-        $supportedLanguages['tr']['dateformat'] = 5;
-        $supportedLanguages['tr']['radixpoint'] = 1;
-
-        // Thai
-        $supportedLanguages['th']['description'] = $clang->gT('Thai');
-        $supportedLanguages['th']['nativedescription'] = '&#3616;&#3634;&#3625;&#3634;&#3652;&#3607;&#3618;';
-        $supportedLanguages['th']['rtl'] = false;
-        $supportedLanguages['th']['dateformat'] = 5;
-        $supportedLanguages['th']['radixpoint'] = 0;
-
-
-        //Urdu
-        $supportedLanguages['ur']['description'] = $clang->gT('Urdu');
-        $supportedLanguages['ur']['nativedescription'] = '&#1575;&#1585;&#1583;&#1608;';
-        $supportedLanguages['ur']['rtl'] = true;
-        $supportedLanguages['ur']['dateformat'] = 2;
-        $supportedLanguages['ur']['radixpoint'] = 0;
-
-        // Vietnamese
-        $supportedLanguages['vi']['description'] = $clang->gT('Vietnamese');
-        $supportedLanguages['vi']['nativedescription'] = 'Ti&#7871;ng Vi&#7879;t';
-        $supportedLanguages['vi']['rtl'] = false;
-        $supportedLanguages['vi']['dateformat'] = 5;
-        $supportedLanguages['vi']['radixpoint'] = 1;
-
-        // Zulu
-        $supportedLanguages['zu']['description'] = $clang->gT('Zulu');
-        $supportedLanguages['zu']['nativedescription'] = 'isiZulu';
-        $supportedLanguages['zu']['rtl'] = false;
-        $supportedLanguages['zu']['dateformat'] = 5;
-        $supportedLanguages['zu']['radixpoint'] = 1;
-
-        if ($bOrderByNative)
-        {
-            uasort($supportedLanguages,"userSortNative");
-        }
-        else
-        {
-            uasort($supportedLanguages,"userSort");
-        }
-
-        $result[$sLanguageCode][$bOrderByNative] = $supportedLanguages;
-
-        Return $supportedLanguages;
-    }
-
-
-    /**
-    *  Returns avaliable formats for Radix Points (Decimal Separators) or returns
-    *  radix point info about a specific format.
-    *
-    *  @param int $format Format ID/Number [optional]
-    */
-    function getRadixPointData($format=-1)
+    if ($iDateFormat >0)
     {
-        $clang = Yii::app()->lang;
-        $aRadixFormats = array (
+        return $aDateFormats[$iDateFormat];
+    }
+    else
+        return $aDateFormats;
+
+}
+
+function getLanguageData($bOrderByNative=false,$sLanguageCode='en') {
+
+    $clang = new Limesurvey_lang($sLanguageCode);
+
+    static $result = array();
+
+    if (isset($result[$sLanguageCode][$bOrderByNative])) return $result[$sLanguageCode][$bOrderByNative];
+
+    // Afrikaans
+    $supportedLanguages['af']['description'] = $clang->gT('Afrikaans');
+    $supportedLanguages['af']['nativedescription'] = 'Afrikaans';
+    $supportedLanguages['af']['rtl'] = false;
+    $supportedLanguages['af']['dateformat'] = 1;
+    $supportedLanguages['af']['radixpoint'] = 1;
+
+    // Albanian
+    $supportedLanguages['sq']['description'] = $clang->gT('Albanian');
+    $supportedLanguages['sq']['nativedescription'] = 'Shqipe';
+    $supportedLanguages['sq']['rtl'] = false;
+    $supportedLanguages['sq']['dateformat'] = 1;
+    $supportedLanguages['sq']['radixpoint'] = 1;
+
+    // Amharic
+    $supportedLanguages['am']['description'] = $clang->gT('Amharic');
+    $supportedLanguages['am']['nativedescription'] = '&#4768;&#4635;&#4653;&#4763;';
+    $supportedLanguages['am']['rtl'] = false;
+    $supportedLanguages['am']['dateformat'] = 2;
+    $supportedLanguages['am']['radixpoint'] = 1;
+
+    // Arabic
+    $supportedLanguages['ar']['description'] = $clang->gT('Arabic');
+    $supportedLanguages['ar']['nativedescription'] = '&#1593;&#1614;&#1585;&#1614;&#1576;&#1610;&#1618;';
+    $supportedLanguages['ar']['rtl'] = true;
+    $supportedLanguages['ar']['dateformat'] = 2;
+    $supportedLanguages['ar']['radixpoint'] = 0;
+
+    // Armenian
+    $supportedLanguages['hy']['description'] = $clang->gT('Armenian');
+    $supportedLanguages['hy']['nativedescription'] = '&#1392;&#1377;&#1397;&#1381;&#1408;&#1381;&#1398;';
+    $supportedLanguages['hy']['rtl'] = false;
+    $supportedLanguages['hy']['dateformat'] = 1;
+    $supportedLanguages['hy']['radixpoint'] = 1;
+
+    // Basque
+    $supportedLanguages['eu']['description'] = $clang->gT('Basque');
+    $supportedLanguages['eu']['nativedescription'] = 'Euskara';
+    $supportedLanguages['eu']['rtl'] = false;
+    $supportedLanguages['eu']['dateformat'] = 3;
+    $supportedLanguages['eu']['radixpoint'] = 1;
+
+    // Belarusian
+    $supportedLanguages['be']['description'] = $clang->gT('Belarusian');
+    $supportedLanguages['be']['nativedescription'] = '&#1041;&#1077;&#1083;&#1072;&#1088;&#1091;&#1089;&#1082;&#1110;';
+    $supportedLanguages['be']['rtl'] = false;
+    $supportedLanguages['be']['dateformat'] = 1;
+    $supportedLanguages['be']['radixpoint'] = 1;
+
+    // Bosnian
+    $supportedLanguages['bs']['description'] = $clang->gT('Bosnian');
+    $supportedLanguages['bs']['nativedescription'] = 'Bosanski';
+    $supportedLanguages['bs']['rtl'] = false;
+    $supportedLanguages['bs']['dateformat'] = 4;
+    $supportedLanguages['bs']['radixpoint'] = 0;
+
+    // Bulgarian
+    $supportedLanguages['bg']['description'] = $clang->gT('Bulgarian');
+    $supportedLanguages['bg']['nativedescription'] = '&#x0411;&#x044a;&#x043b;&#x0433;&#x0430;&#x0440;&#x0441;&#x043a;&#x0438;';
+    $supportedLanguages['bg']['rtl'] = false;
+    $supportedLanguages['bg']['dateformat'] = 1;
+    $supportedLanguages['bg']['radixpoint'] = 0;
+
+    // Catalan
+    $supportedLanguages['ca-valencia']['description'] = $clang->gT('Catalan (Valencian)');
+    $supportedLanguages['ca-valencia']['nativedescription'] = 'Catal&#224; (Valenci&#224;)';
+    $supportedLanguages['ca-valencia']['rtl'] = false;
+    $supportedLanguages['ca-valencia']['dateformat'] = 1;
+    $supportedLanguages['ca-valencia']['radixpoint'] = 1;
+
+    // Catalan
+    $supportedLanguages['ca']['description'] = $clang->gT('Catalan');
+    $supportedLanguages['ca']['nativedescription'] = 'Catal&#224;';
+    $supportedLanguages['ca']['rtl'] = false;
+    $supportedLanguages['ca']['dateformat'] = 1;
+    $supportedLanguages['ca']['radixpoint'] = 1;
+
+    // Welsh
+    $supportedLanguages['cy']['description'] = $clang->gT('Welsh');
+    $supportedLanguages['cy']['nativedescription'] = 'Cymraeg';
+    $supportedLanguages['cy']['rtl'] = false;
+    $supportedLanguages['cy']['dateformat'] = 5;
+    $supportedLanguages['cy']['radixpoint'] = 0;
+
+    // Chinese (Simplified)
+    $supportedLanguages['zh-Hans']['description'] = $clang->gT('Chinese (Simplified)');
+    $supportedLanguages['zh-Hans']['nativedescription'] = '&#31616;&#20307;&#20013;&#25991;';
+    $supportedLanguages['zh-Hans']['rtl'] = false;
+    $supportedLanguages['zh-Hans']['dateformat'] = 6;
+    $supportedLanguages['zh-Hans']['radixpoint'] = 0;
+
+    // Chinese (Traditional - Hong Kong)
+    $supportedLanguages['zh-Hant-HK']['description'] = $clang->gT('Chinese (Traditional - Hong Kong)');
+    $supportedLanguages['zh-Hant-HK']['nativedescription'] = '&#32321;&#39636;&#20013;&#25991;&#35486;&#31995;';
+    $supportedLanguages['zh-Hant-HK']['rtl'] = false;
+    $supportedLanguages['zh-Hant-HK']['dateformat'] = 6;
+    $supportedLanguages['zh-Hant-HK']['radixpoint'] = 0;
+
+    // Chinese (Traditional - Taiwan)
+    $supportedLanguages['zh-Hant-TW']['description'] = $clang->gT('Chinese (Traditional - Taiwan)');
+    $supportedLanguages['zh-Hant-TW']['nativedescription'] = '&#32321;&#39636;&#20013;&#25991;&#65288;&#21488;&#28771;&#65289;';
+    $supportedLanguages['zh-Hant-TW']['rtl'] = false;
+    $supportedLanguages['zh-Hant-TW']['dateformat'] = 6;
+    $supportedLanguages['zh-Hant-TW']['radixpoint'] = 0;
+
+    // Croatian
+    $supportedLanguages['hr']['description'] = $clang->gT('Croatian');
+    $supportedLanguages['hr']['nativedescription'] = 'Hrvatski';
+    $supportedLanguages['hr']['rtl'] = false;
+    $supportedLanguages['hr']['dateformat'] = 4;
+    $supportedLanguages['hr']['radixpoint'] = 1;
+
+    // Czech
+    $supportedLanguages['cs']['description'] = $clang->gT('Czech');
+    $supportedLanguages['cs']['nativedescription'] = '&#x010c;esky';
+    $supportedLanguages['cs']['rtl'] = false;
+    $supportedLanguages['cs']['dateformat'] = 4;
+    $supportedLanguages['cs']['radixpoint'] = 1;
+
+    // Czech informal
+    $supportedLanguages['cs-informal']['description'] = $clang->gT('Czech (informal)');
+    $supportedLanguages['cs-informal']['nativedescription'] = '&#x010c;esky neform&aacute;ln&iacute;';
+    $supportedLanguages['cs-informal']['rtl'] = false;
+    $supportedLanguages['cs-informal']['dateformat'] = 4;
+    $supportedLanguages['cs-informal']['radixpoint'] = 1;
+
+
+    // Danish
+    $supportedLanguages['da']['description'] = $clang->gT('Danish');
+    $supportedLanguages['da']['nativedescription'] = 'Dansk';
+    $supportedLanguages['da']['rtl'] = false;
+    $supportedLanguages['da']['dateformat'] =  2;
+    $supportedLanguages['da']['radixpoint'] = 1;
+
+    // Dari
+    $supportedLanguages['prs']['description'] = $clang->gT('Dari');
+    $supportedLanguages['prs']['nativedescription'] = '&#1583;&#1585;&#1740;';
+    $supportedLanguages['prs']['rtl'] = true;
+    $supportedLanguages['prs']['dateformat'] = 6;
+    $supportedLanguages['prs']['radixpoint'] = 0;
+
+    // Dutch
+    $supportedLanguages['nl']['description'] = $clang->gT('Dutch');
+    $supportedLanguages['nl']['nativedescription'] = 'Nederlands';
+    $supportedLanguages['nl']['rtl'] = false;
+    $supportedLanguages['nl']['dateformat'] = 2;
+    $supportedLanguages['nl']['radixpoint'] = 1;
+
+    // Dutch
+    $supportedLanguages['nl-informal']['description'] = $clang->gT('Dutch (informal)');
+    $supportedLanguages['nl-informal']['nativedescription'] = 'Nederlands (informeel)';
+    $supportedLanguages['nl-informal']['rtl'] = false;
+    $supportedLanguages['nl-informal']['dateformat'] = 2;
+    $supportedLanguages['nl-informal']['radixpoint'] = 1;
+
+    // English
+    $supportedLanguages['en']['description'] = $clang->gT('English');
+    $supportedLanguages['en']['nativedescription'] = 'English';
+    $supportedLanguages['en']['rtl'] = false;
+    $supportedLanguages['en']['dateformat'] = 9;
+    $supportedLanguages['en']['radixpoint'] = 0;
+
+    // Estonian
+    $supportedLanguages['et']['description'] = $clang->gT('Estonian');
+    $supportedLanguages['et']['nativedescription'] = 'Eesti';
+    $supportedLanguages['et']['rtl'] = false;
+    $supportedLanguages['et']['dateformat'] = 4;
+    $supportedLanguages['et']['radixpoint'] = 1;
+
+    // Finnish
+    $supportedLanguages['fi']['description'] = $clang->gT('Finnish');
+    $supportedLanguages['fi']['nativedescription'] = 'Suomi';
+    $supportedLanguages['fi']['rtl'] = false;
+    $supportedLanguages['fi']['dateformat'] = 4;
+    $supportedLanguages['fi']['radixpoint'] = 1;
+
+    // French
+    $supportedLanguages['fr']['description'] = $clang->gT('French');
+    $supportedLanguages['fr']['nativedescription'] = 'Fran&#231;ais';
+    $supportedLanguages['fr']['rtl'] = false;
+    $supportedLanguages['fr']['dateformat'] = 5;
+    $supportedLanguages['fr']['radixpoint'] = 1;
+
+    // Fula
+    $supportedLanguages['ful']['description'] = $clang->gT('Fula');
+    $supportedLanguages['ful']['nativedescription'] = 'Fulfulde';
+    $supportedLanguages['ful']['rtl'] = false;
+    $supportedLanguages['ful']['dateformat'] = 5;
+    $supportedLanguages['ful']['radixpoint'] = 1;
+
+    // Galician
+    $supportedLanguages['gl']['description'] = $clang->gT('Galician');
+    $supportedLanguages['gl']['nativedescription'] = 'Galego';
+    $supportedLanguages['gl']['rtl'] = false;
+    $supportedLanguages['gl']['dateformat'] = 5;
+    $supportedLanguages['gl']['radixpoint'] = 1;
+
+    // Georgian
+    $supportedLanguages['ka']['description'] = $clang->gT('Georgian');
+    $supportedLanguages['ka']['nativedescription'] = '&#4325;&#4304;&#4320;&#4311;&#4323;&#4314;&#4312; &#4308;&#4316;&#4304;';
+    $supportedLanguages['ka']['rtl'] = false;
+    $supportedLanguages['ka']['dateformat'] = 1;
+    $supportedLanguages['ka']['radixpoint'] = 1;
+
+    // German
+    $supportedLanguages['de']['description'] = $clang->gT('German');
+    $supportedLanguages['de']['nativedescription'] = 'Deutsch';
+    $supportedLanguages['de']['rtl'] = false;
+    $supportedLanguages['de']['dateformat'] = 1;
+    $supportedLanguages['de']['radixpoint'] = 1;
+
+    // German informal
+    $supportedLanguages['de-informal']['description'] = $clang->gT('German (informal)');
+    $supportedLanguages['de-informal']['nativedescription'] = 'Deutsch (Du)';
+    $supportedLanguages['de-informal']['rtl'] = false;
+    $supportedLanguages['de-informal']['dateformat'] = 1;
+    $supportedLanguages['de-informal']['radixpoint'] = 1;
+
+    // Gujarati
+    $supportedLanguages['gu']['description'] = $clang->gT('Gujarati');
+    $supportedLanguages['gu']['nativedescription'] = '&#2711;&#2753;&#2716;&#2736;&#2750;&#2724;&#2752;';
+    $supportedLanguages['gu']['rtl'] = false;
+    $supportedLanguages['gu']['dateformat'] = 2;
+    $supportedLanguages['gu']['radixpoint'] = 0;
+
+    // Greek
+    $supportedLanguages['el']['description'] = $clang->gT('Greek');
+    $supportedLanguages['el']['nativedescription'] = '&#949;&#955;&#955;&#951;&#957;&#953;&#954;&#940;';
+    $supportedLanguages['el']['rtl'] = false;
+    $supportedLanguages['el']['dateformat'] = 8;
+    $supportedLanguages['el']['radixpoint'] = 1;
+
+    // Hindi
+    $supportedLanguages['hi']['description'] = $clang->gT('Hindi');
+    $supportedLanguages['hi']['nativedescription'] = '&#2361;&#2367;&#2344;&#2381;&#2342;&#2368;';
+    $supportedLanguages['hi']['rtl'] = false;
+    $supportedLanguages['hi']['dateformat'] = 2;
+    $supportedLanguages['hi']['radixpoint'] = 0;
+
+    // Hebrew
+    $supportedLanguages['he']['description'] = $clang->gT('Hebrew');
+    $supportedLanguages['he']['nativedescription'] = ' &#1506;&#1489;&#1512;&#1497;&#1514;';
+    $supportedLanguages['he']['rtl'] = true;
+    $supportedLanguages['he']['dateformat'] = 5;
+    $supportedLanguages['he']['radixpoint'] = 0;
+
+    // Hungarian
+    $supportedLanguages['hu']['description'] = $clang->gT('Hungarian');
+    $supportedLanguages['hu']['nativedescription'] = 'Magyar';
+    $supportedLanguages['hu']['rtl'] = false;
+    $supportedLanguages['hu']['dateformat'] = 6;
+    $supportedLanguages['hu']['radixpoint'] = 1;
+
+    // Icelandic
+    $supportedLanguages['is']['description'] = $clang->gT('Icelandic');
+    $supportedLanguages['is']['nativedescription'] = '&#237;slenska';
+    $supportedLanguages['is']['rtl'] = false;
+    $supportedLanguages['is']['dateformat'] = 1;
+    $supportedLanguages['is']['radixpoint'] = 1;
+
+    // Indonesian
+    $supportedLanguages['id']['description'] = $clang->gT('Indonesian');
+    $supportedLanguages['id']['nativedescription'] = 'Bahasa Indonesia';
+    $supportedLanguages['id']['rtl'] = false;
+    $supportedLanguages['id']['dateformat'] = 5;
+    $supportedLanguages['id']['radixpoint'] = 1;
+
+    // Irish
+    $supportedLanguages['ie']['description'] = $clang->gT('Irish');
+    $supportedLanguages['ie']['nativedescription'] = 'Gaeilge';
+    $supportedLanguages['ie']['rtl'] = false;
+    $supportedLanguages['ie']['dateformat'] = 2;
+    $supportedLanguages['ie']['radixpoint'] = 0;
+
+    // Italian
+    $supportedLanguages['it']['description'] = $clang->gT('Italian');
+    $supportedLanguages['it']['nativedescription'] = 'Italiano';
+    $supportedLanguages['it']['rtl'] = false;
+    $supportedLanguages['it']['dateformat'] = 5;
+    $supportedLanguages['it']['radixpoint'] = 1;
+
+    // Italian informal
+    $supportedLanguages['it-informal']['description'] = $clang->gT('Italian (informal)');
+    $supportedLanguages['it-informal']['nativedescription'] = 'Italiano (informale)';
+    $supportedLanguages['it-informal']['rtl'] = false;
+    $supportedLanguages['it-informal']['dateformat'] = 5;
+    $supportedLanguages['it-informal']['radixpoint'] = 1;
+
+    // Japanese
+    $supportedLanguages['ja']['description'] = $clang->gT('Japanese');
+    $supportedLanguages['ja']['nativedescription'] = '&#x65e5;&#x672c;&#x8a9e;';
+    $supportedLanguages['ja']['rtl'] = false;
+    $supportedLanguages['ja']['dateformat'] = 6;
+    $supportedLanguages['ja']['radixpoint'] = 0;
+
+    // Kinyarwanda
+    $supportedLanguages['rw']['description'] = $clang->gT('Kinyarwanda');
+    $supportedLanguages['rw']['nativedescription'] = 'Kinyarwanda';
+    $supportedLanguages['rw']['rtl'] = false;
+    $supportedLanguages['rw']['dateformat'] = 5;
+    $supportedLanguages['rw']['radixpoint'] = 1;
+
+    // Korean
+    $supportedLanguages['ko']['description'] = $clang->gT('Korean');
+    $supportedLanguages['ko']['nativedescription'] = '&#54620;&#44397;&#50612;';
+    $supportedLanguages['ko']['rtl'] = false;
+    $supportedLanguages['ko']['dateformat'] = 7;
+    $supportedLanguages['ko']['radixpoint'] = 0;
+
+    // Kurdish (Sorani)
+    $supportedLanguages['ckb']['description'] = $clang->gT('Kurdish (Sorani)');
+    $supportedLanguages['ckb']['nativedescription'] = '&#1705;&#1608;&#1585;&#1583;&#1740;&#1740; &#1606;&#1575;&#1608;&#1749;&#1606;&#1583;&#1740;';
+    $supportedLanguages['ckb']['rtl'] = true;
+    $supportedLanguages['ckb']['dateformat'] = 1;
+    $supportedLanguages['ckb']['radixpoint'] = 1;
+
+
+    // Lithuanian
+    $supportedLanguages['lt']['description'] = $clang->gT('Lithuanian');
+    $supportedLanguages['lt']['nativedescription'] = 'Lietuvi&#371;';
+    $supportedLanguages['lt']['rtl'] = false;
+    $supportedLanguages['lt']['dateformat'] = 6;
+    $supportedLanguages['lt']['radixpoint'] = 1;
+
+    // Latvian
+    $supportedLanguages['lv']['description'] = $clang->gT('Latvian');
+    $supportedLanguages['lv']['nativedescription'] = 'Latvie&#353;u';
+    $supportedLanguages['lv']['rtl'] = false;
+    $supportedLanguages['lv']['dateformat'] = 6;
+    $supportedLanguages['lv']['radixpoint'] = 1;
+
+    // Macedonian
+    $supportedLanguages['mk']['description'] = $clang->gT('Macedonian');
+    $supportedLanguages['mk']['nativedescription'] = '&#1052;&#1072;&#1082;&#1077;&#1076;&#1086;&#1085;&#1089;&#1082;&#1080;';
+    $supportedLanguages['mk']['rtl'] = false;
+    $supportedLanguages['mk']['dateformat'] = 1;
+    $supportedLanguages['mk']['radixpoint'] = 1;
+
+    // Mongolian
+    $supportedLanguages['mn']['description'] = $clang->gT('Mongolian');
+    $supportedLanguages['mn']['nativedescription'] = '&#1052;&#1086;&#1085;&#1075;&#1086;&#1083;';
+    $supportedLanguages['mn']['rtl'] = false;
+    $supportedLanguages['mn']['dateformat'] = 3;
+    $supportedLanguages['mn']['radixpoint'] = 0;
+
+    // Malay
+    $supportedLanguages['ms']['description'] = $clang->gT('Malay');
+    $supportedLanguages['ms']['nativedescription'] = 'Bahasa Melayu';
+    $supportedLanguages['ms']['rtl'] = false;
+    $supportedLanguages['ms']['dateformat'] = 1;
+    $supportedLanguages['ms']['radixpoint'] = 0;
+
+    // Maltese
+    $supportedLanguages['mt']['description'] = $clang->gT('Maltese');
+    $supportedLanguages['mt']['nativedescription'] = 'Malti';
+    $supportedLanguages['mt']['rtl'] = false;
+    $supportedLanguages['mt']['dateformat'] = 1;
+    $supportedLanguages['mt']['radixpoint'] = 0;
+
+    // Marathi
+    $supportedLanguages['mr']['description'] = $clang->gT('Marathi');
+    $supportedLanguages['mr']['nativedescription'] = '&#2350;&#2352;&#2366;&#2336;&#2368;';
+    $supportedLanguages['mr']['rtl'] = false;
+    $supportedLanguages['mr']['dateformat'] = 2;
+    $supportedLanguages['mr']['radixpoint'] = 0;
+
+    // Norwegian Bokmal
+    $supportedLanguages['nb']['description'] = $clang->gT('Norwegian (Bokmal)');
+    $supportedLanguages['nb']['nativedescription'] = 'Norsk Bokm&#229;l';
+    $supportedLanguages['nb']['rtl'] = false;
+    $supportedLanguages['nb']['dateformat'] = 4;
+    $supportedLanguages['nb']['radixpoint'] = 1;
+
+    // Norwegian Nynorsk
+    $supportedLanguages['nn']['description'] = $clang->gT('Norwegian (Nynorsk)');
+    $supportedLanguages['nn']['nativedescription'] = 'Norsk Nynorsk';
+    $supportedLanguages['nn']['rtl'] = false;
+    $supportedLanguages['nn']['dateformat'] = 4;
+    $supportedLanguages['nn']['radixpoint'] = 1;
+
+    // Occitan
+    $supportedLanguages['oc']['description'] = $clang->gT('Occitan');
+    $supportedLanguages['oc']['nativedescription'] = 'Lenga d&#39;&#242;c';
+    $supportedLanguages['oc']['rtl'] = false;
+    $supportedLanguages['oc']['dateformat'] = 5;
+    $supportedLanguages['oc']['radixpoint'] = 1;
+
+    // Pashto
+    $supportedLanguages['ps']['description'] = $clang->gT('Pashto');
+    $supportedLanguages['ps']['nativedescription'] = '&#1662;&#1690;&#1578;&#1608;';
+    $supportedLanguages['ps']['rtl'] = true;
+    $supportedLanguages['ps']['dateformat'] = 6;
+    $supportedLanguages['ps']['radixpoint'] = 0;
+
+    // Persian
+    $supportedLanguages['fa']['description'] = $clang->gT('Persian');
+    $supportedLanguages['fa']['nativedescription'] = '&#1601;&#1575;&#1585;&#1587;&#1740;';
+    $supportedLanguages['fa']['rtl'] = true;
+    $supportedLanguages['fa']['dateformat'] = 6;
+    $supportedLanguages['fa']['radixpoint'] = 0;
+
+    // Papiamento (Aruba)
+    $supportedLanguages['pap-AW']['description'] = $clang->gT('Papiamento (Aruba)');
+    $supportedLanguages['pap-AW']['nativedescription'] = 'Papiamento';
+    $supportedLanguages['pap-AW']['rtl'] = false;
+    $supportedLanguages['pap-AW']['dateformat'] = 2;
+    $supportedLanguages['pap-AW']['radixpoint'] = 1;
+
+    // Papiamento (Curaçao and Bonaire)
+    $supportedLanguages['pap-CW']['description'] = $clang->gT('Papiamento (Curaçao and Bonaire)');
+    $supportedLanguages['pap-CW']['nativedescription'] = 'Papiamentu';
+    $supportedLanguages['pap-CW']['rtl'] = false;
+    $supportedLanguages['pap-CW']['dateformat'] = 2;
+    $supportedLanguages['pap-CW']['radixpoint'] = 1;
+
+    // Polish
+    $supportedLanguages['pl']['description'] = $clang->gT('Polish');
+    $supportedLanguages['pl']['nativedescription'] = 'Polski';
+    $supportedLanguages['pl']['rtl'] = false;
+    $supportedLanguages['pl']['dateformat'] = 1;
+    $supportedLanguages['pl']['radixpoint'] = 1;
+
+    // Portuguese
+    $supportedLanguages['pt']['description'] = $clang->gT('Portuguese');
+    $supportedLanguages['pt']['nativedescription'] = 'Portugu&#234;s';
+    $supportedLanguages['pt']['rtl'] = false;
+    $supportedLanguages['pt']['dateformat'] = 5;
+    $supportedLanguages['pt']['radixpoint'] = 1;
+
+    // Brazilian Portuguese
+    $supportedLanguages['pt-BR']['description'] = $clang->gT('Portuguese (Brazilian)');
+    $supportedLanguages['pt-BR']['nativedescription'] = 'Portugu&#234;s do Brasil';
+    $supportedLanguages['pt-BR']['rtl'] = false;
+    $supportedLanguages['pt-BR']['dateformat'] = 5;
+    $supportedLanguages['pt-BR']['radixpoint'] = 1;
+
+    // Punjabi
+    $supportedLanguages['pa']['description'] = $clang->gT('Punjabi');
+    $supportedLanguages['pa']['nativedescription'] = '&#2602;&#2672;&#2588;&#2622;&#2604;&#2624;';
+    $supportedLanguages['pa']['rtl'] = false;
+    $supportedLanguages['pa']['dateformat'] = 2;
+    $supportedLanguages['pa']['radixpoint'] = 0;
+
+    // Russian
+    $supportedLanguages['ru']['description'] = $clang->gT('Russian');
+    $supportedLanguages['ru']['nativedescription'] = '&#1056;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;';
+    $supportedLanguages['ru']['rtl'] = false;
+    $supportedLanguages['ru']['dateformat'] = 1;
+    $supportedLanguages['ru']['radixpoint'] = 1;
+
+    // Romanian
+    $supportedLanguages['ro']['description'] = $clang->gT('Romanian');
+    $supportedLanguages['ro']['nativedescription'] = 'Rom&#226;na';
+    $supportedLanguages['ro']['rtl'] = false;
+    $supportedLanguages['ro']['dateformat'] = 1;
+    $supportedLanguages['ro']['radixpoint'] = 1;
+
+    // Slovak
+    $supportedLanguages['sk']['description'] = $clang->gT('Slovak');
+    $supportedLanguages['sk']['nativedescription'] = 'Sloven&#269;ina';
+    $supportedLanguages['sk']['rtl'] = false;
+    $supportedLanguages['sk']['dateformat'] = 4;
+    $supportedLanguages['sk']['radixpoint'] = 1;
+
+    // Sinhala
+    $supportedLanguages['si']['description'] = $clang->gT('Sinhala');
+    $supportedLanguages['si']['nativedescription'] = '&#3523;&#3538;&#3458;&#3524;&#3517;';
+    $supportedLanguages['si']['rtl'] = false;
+    $supportedLanguages['si']['dateformat'] = 5;
+    $supportedLanguages['si']['radixpoint'] = 0;
+
+    // Slovenian
+    $supportedLanguages['sl']['description'] = $clang->gT('Slovenian');
+    $supportedLanguages['sl']['nativedescription'] = 'Sloven&#353;&#269;ina';
+    $supportedLanguages['sl']['rtl'] = false;
+    $supportedLanguages['sl']['dateformat'] = 4;
+    $supportedLanguages['sl']['radixpoint'] = 1;
+
+    // Serbian
+    $supportedLanguages['sr']['description'] = $clang->gT('Serbian (Cyrillic)');
+    $supportedLanguages['sr']['nativedescription'] = '&#1057;&#1088;&#1087;&#1089;&#1082;&#1080;';
+    $supportedLanguages['sr']['rtl'] = false;
+    $supportedLanguages['sr']['dateformat'] = 4;
+    $supportedLanguages['sr']['radixpoint'] = 1;
+
+    // Serbian (Latin script)
+    $supportedLanguages['sr-Latn']['description'] = $clang->gT('Serbian (Latin)');
+    $supportedLanguages['sr-Latn']['nativedescription'] = 'Srpski';
+    $supportedLanguages['sr-Latn']['rtl'] = false;
+    $supportedLanguages['sr-Latn']['dateformat'] = 4;
+    $supportedLanguages['sr-Latn']['radixpoint'] = 1;
+
+    // Spanish
+    $supportedLanguages['es']['description'] = $clang->gT('Spanish');
+    $supportedLanguages['es']['nativedescription'] = 'Espa&#241;ol';
+    $supportedLanguages['es']['rtl'] = false;
+    $supportedLanguages['es']['dateformat'] = 5;
+    $supportedLanguages['es']['radixpoint'] = 1;
+
+    // Spanish (Argentina)
+    $supportedLanguages['es-AR']['description'] = $clang->gT('Spanish (Argentina)');
+    $supportedLanguages['es-AR']['nativedescription'] = 'Espa&#241;ol rioplatense';
+    $supportedLanguages['es-AR']['rtl'] = false;
+    $supportedLanguages['es-AR']['dateformat'] = 5;
+    $supportedLanguages['es-AR']['radixpoint'] = 0;
+
+    // Spanish (Argentina) (Informal)
+    $supportedLanguages['es-AR-informal']['description'] = $clang->gT('Spanish (Argentina) (Informal)');
+    $supportedLanguages['es-AR-informal']['nativedescription'] = 'Espa&#241;ol rioplatense informal';
+    $supportedLanguages['es-AR-informal']['rtl'] = false;
+    $supportedLanguages['es-AR-informal']['dateformat'] = 5;
+    $supportedLanguages['es-AR-informal']['radixpoint'] = 0;
+
+    // Spanish (Chile)
+    $supportedLanguages['es-CL']['description'] = $clang->gT('Spanish (Chile)');
+    $supportedLanguages['es-CL']['nativedescription'] = 'Espa&#241;ol chileno';
+    $supportedLanguages['es-CL']['rtl'] = false;
+    $supportedLanguages['es-CL']['dateformat'] = 5;
+    $supportedLanguages['es-CL']['radixpoint'] = 0;
+
+    // Spanish (Mexico)
+    $supportedLanguages['es-MX']['description'] = $clang->gT('Spanish (Mexico)');
+    $supportedLanguages['es-MX']['nativedescription'] = 'Espa&#241;ol mexicano';
+    $supportedLanguages['es-MX']['rtl'] = false;
+    $supportedLanguages['es-MX']['dateformat'] = 5;
+    $supportedLanguages['es-MX']['radixpoint'] = 0;
+
+    // Swahili
+    $supportedLanguages['swh']['description'] = $clang->gT('Swahili');
+    $supportedLanguages['swh']['nativedescription'] = 'Kiswahili';
+    $supportedLanguages['swh']['rtl'] = false;
+    $supportedLanguages['swh']['dateformat'] = 1;
+    $supportedLanguages['swh']['radixpoint'] = 1;
+
+    // Swedish
+    $supportedLanguages['sv']['description'] = $clang->gT('Swedish');
+    $supportedLanguages['sv']['nativedescription'] = 'Svenska';
+    $supportedLanguages['sv']['rtl'] = false;
+    $supportedLanguages['sv']['dateformat'] = 6;
+    $supportedLanguages['sv']['radixpoint'] = 1;
+
+    // Tamil
+    $supportedLanguages['ta']['description'] = $clang->gT('Tamil');
+    $supportedLanguages['ta']['nativedescription'] = '&#2980;&#2990;&#3007;&#2996;&#3021;';
+    $supportedLanguages['ta']['rtl'] = false;
+    $supportedLanguages['ta']['dateformat'] = 2;
+    $supportedLanguages['ta']['radixpoint'] = 0;
+
+    // Turkish
+    $supportedLanguages['tr']['description'] = $clang->gT('Turkish');
+    $supportedLanguages['tr']['nativedescription'] = 'T&#252;rk&#231;e';
+    $supportedLanguages['tr']['rtl'] = false;
+    $supportedLanguages['tr']['dateformat'] = 5;
+    $supportedLanguages['tr']['radixpoint'] = 1;
+
+    // Thai
+    $supportedLanguages['th']['description'] = $clang->gT('Thai');
+    $supportedLanguages['th']['nativedescription'] = '&#3616;&#3634;&#3625;&#3634;&#3652;&#3607;&#3618;';
+    $supportedLanguages['th']['rtl'] = false;
+    $supportedLanguages['th']['dateformat'] = 5;
+    $supportedLanguages['th']['radixpoint'] = 0;
+
+
+    //Urdu
+    $supportedLanguages['ur']['description'] = $clang->gT('Urdu');
+    $supportedLanguages['ur']['nativedescription'] = '&#1575;&#1585;&#1583;&#1608;';
+    $supportedLanguages['ur']['rtl'] = true;
+    $supportedLanguages['ur']['dateformat'] = 2;
+    $supportedLanguages['ur']['radixpoint'] = 0;
+
+    // Vietnamese
+    $supportedLanguages['vi']['description'] = $clang->gT('Vietnamese');
+    $supportedLanguages['vi']['nativedescription'] = 'Ti&#7871;ng Vi&#7879;t';
+    $supportedLanguages['vi']['rtl'] = false;
+    $supportedLanguages['vi']['dateformat'] = 5;
+    $supportedLanguages['vi']['radixpoint'] = 1;
+
+    // Zulu
+    $supportedLanguages['zu']['description'] = $clang->gT('Zulu');
+    $supportedLanguages['zu']['nativedescription'] = 'isiZulu';
+    $supportedLanguages['zu']['rtl'] = false;
+    $supportedLanguages['zu']['dateformat'] = 5;
+    $supportedLanguages['zu']['radixpoint'] = 1;
+
+    if ($bOrderByNative)
+    {
+        uasort($supportedLanguages,"userSortNative");
+    }
+    else
+    {
+        uasort($supportedLanguages,"userSort");
+    }
+
+    $result[$sLanguageCode][$bOrderByNative] = $supportedLanguages;
+
+    Return $supportedLanguages;
+}
+
+
+/**
+ *  Returns avaliable formats for Radix Points (Decimal Separators) or returns
+ *  radix point info about a specific format.
+ *
+ *  @param int $format Format ID/Number [optional]
+ */
+function getRadixPointData($format=-1)
+{
+    $clang = Yii::app()->lang;
+    $aRadixFormats = array (
         0=>array('separator'=> '.', 'desc'=> $clang->gT('Dot (.)')),
         1=>array('separator'=> ',', 'desc'=> $clang->gT('Comma (,)'))
-        );
+    );
 
-        // hack for fact that null sometimes sent to this function
-        if (is_null($format)) {
-            $format = 0;
-        }
-
-        if ($format >= 0)
-            return $aRadixFormats[$format];
-        else
-            return $aRadixFormats;
+    // hack for fact that null sometimes sent to this function
+    if (is_null($format)) {
+        $format = 0;
     }
 
+    if ($format >= 0)
+        return $aRadixFormats[$format];
+    else
+        return $aRadixFormats;
+}
 
-    /**
-    * Convert a 'dateformat' format string to a 'phpdate' format.
-    *
-    * @param $sDateformat string
-    * @returns string
-    *
-    */
-    function getPHPDateFromDateFormat($sDateformat)
-    {
-        // Note that order is relevant (longer strings first)
-        $aFmts = array(
+
+/**
+ * Convert a 'dateformat' format string to a 'phpdate' format.
+ *
+ * @param $sDateformat string
+ * @returns string
+ *
+ */
+function getPHPDateFromDateFormat($sDateformat)
+{
+    // Note that order is relevant (longer strings first)
+    $aFmts = array(
         // With leading zero
         "dd"   => "d",
         "mm"   => "m",
@@ -716,281 +713,282 @@
         "m"    => "n",
         "yy"   => "y",
         "H"    => "G",
-        "M"    => "i");
+        "M"    => "i"
+    );
 
-        // Extra allowed characters
-        $aAllowed = array('-', '.', '/', ':', ' ');
+    // Extra allowed characters
+    $aAllowed = array('-', '.', '/', ':', ' ');
 
-        // Convert
-        $tmp = array();
-        foreach ($aAllowed as $k)
+    // Convert
+    $tmp = array();
+    foreach ($aAllowed as $k)
+    {
+        $tmp[$k] = true;
+    }
+    foreach (array_values($aFmts) as $k)
+    {
+        for ($i = 0; $i < strlen($k); $i++)
         {
-            $tmp[$k] = true;
+            $tmp[$k[$i]] = true;
         }
-        foreach (array_values($aFmts) as $k)
-        {
-            for ($i = 0; $i < strlen($k); $i++)
-            {
-                $tmp[$k[$i]] = true;
-            }
-        }
-        $aAllowed = $tmp;
+    }
+    $aAllowed = $tmp;
 
-        $tmp = strtr($sDateformat, $aFmts);
-        $sPhpdate = "";
-        for ($i = 0; $i < strlen($tmp); $i++)
+    $tmp = strtr($sDateformat, $aFmts);
+    $sPhpdate = "";
+    for ($i = 0; $i < strlen($tmp); $i++)
+    {
+        $c = $tmp[$i];
+        if(isset($aAllowed[$c]))
         {
-            $c = $tmp[$i];
-            if(isset($aAllowed[$c]))
-            {
-                $sPhpdate .= $c;
-            }
+            $sPhpdate .= $c;
         }
-
-        return $sPhpdate;
     }
 
+    return $sPhpdate;
+}
 
-    /**
-    * Convert a 'dateformat' format string to a 'jsdate' format.
-    *
-    * @param $sDateformat string
-    * @returns string
-    *
-    */
-    function getJSDateFromDateFormat($sDateformat)
+
+/**
+ * Convert a 'dateformat' format string to a 'jsdate' format.
+ *
+ * @param $sDateformat string
+ * @returns string
+ *
+ */
+function getJSDateFromDateFormat($sDateformat)
+{
+    // The only difference from dateformat is that Jsdate does not support truncated years
+    return str_replace(array('yy'), array('y'), $sDateformat);
+}
+
+
+/**
+ * Get the date format details for a specific question.
+ *
+ * @param $aQidAttributes array Question attributes
+ * @param $mThisSurvey mixed Array of Survey attributes or surveyid
+ * @returns array
+ *
+ */
+function getDateFormatDataForQID($aQidAttributes, $mThisSurvey)
+{
+    if (isset($aQidAttributes['date_format']) && trim($aQidAttributes['date_format'])!='')
     {
-        // The only difference from dateformat is that Jsdate does not support truncated years
-        return str_replace(array('yy'), array('y'), $sDateformat);
+        $aDateFormatDetails = array();
+        $aDateFormatDetails['dateformat'] = trim($aQidAttributes['date_format']);
+        $aDateFormatDetails['phpdate'] = getPHPDateFromDateFormat($aDateFormatDetails['dateformat']);
+        $aDateFormatDetails['jsdate'] = getJSDateFromDateFormat($aDateFormatDetails['dateformat']);
     }
-
-
-    /**
-    * Get the date format details for a specific question.
-    *
-    * @param $aQidAttributes array Question attributes
-    * @param $mThisSurvey mixed Array of Survey attributes or surveyid
-    * @returns array
-    *
-    */
-    function getDateFormatDataForQID($aQidAttributes, $mThisSurvey)
+    else
     {
-        if (isset($aQidAttributes['date_format']) && trim($aQidAttributes['date_format'])!='')
+        if(!is_array($mThisSurvey))
         {
-            $aDateFormatDetails = array();
-            $aDateFormatDetails['dateformat'] = trim($aQidAttributes['date_format']);
-            $aDateFormatDetails['phpdate'] = getPHPDateFromDateFormat($aDateFormatDetails['dateformat']);
-            $aDateFormatDetails['jsdate'] = getJSDateFromDateFormat($aDateFormatDetails['dateformat']);
+            $mThisSurvey = array('surveyls_dateformat' => getDateFormatForSID($mThisSurvey));
         }
-        else
-        {
-            if(!is_array($mThisSurvey))
-            {
-                $mThisSurvey = array('surveyls_dateformat' => getDateFormatForSID($mThisSurvey));
-            }
-            $aDateFormatDetails = getDateFormatData($mThisSurvey['surveyls_dateformat']);
-        }
-        return $aDateFormatDetails;
+        $aDateFormatDetails = getDateFormatData($mThisSurvey['surveyls_dateformat']);
     }
+    return $aDateFormatDetails;
+}
 
 
-    /**
-    * Get the date format for a specified survey
-    *
-    * @param $surveyid integer Survey id
-    * @param $languagecode string Survey language code (optional)
-    * @returns integer
-    *
-    */
-    function getDateFormatForSID($surveyid, $languagecode='')
+/**
+ * Get the date format for a specified survey
+ *
+ * @param $surveyid integer Survey id
+ * @param $languagecode string Survey language code (optional)
+ * @returns integer
+ *
+ */
+function getDateFormatForSID($surveyid, $languagecode='')
+{
+    if (!isset($languagecode) || $languagecode=='')
     {
-        if (!isset($languagecode) || $languagecode=='')
-        {
-            $languagecode=Survey::model()->findByPk($surveyid)->language;
-        }
-        $data = SurveyLanguageSetting::model()->getDateFormat($surveyid,$languagecode);
-
-        if(empty($data))
-        {
-            $dateformat = 0;
-        }
-        else
-        {
-            $dateformat = (int) $data;
-        }
-        return (int) $dateformat;
+        $languagecode=Survey::model()->findByPk($surveyid)->language;
     }
+    $data = SurveyLanguageSetting::model()->getDateFormat($surveyid,$languagecode);
 
-
-    /**
-    * Check whether we can show the JS date picker with the current format
-    *
-    * @param $dateformatdetails array Date format details for the question
-    * @param $dateformats array Available date formats
-    * @returns integer
-    *
-    */
-    function canShowDatePicker($dateformatdetails, $dateformats=null)
+    if(empty($data))
     {
-        if(is_null($dateformats))
-        {
-            $dateformats = getDateFormatData();
-        }
-        $showpicker = false;
-        foreach($dateformats as $format)
-        {
-            if($format['jsdate'] == $dateformatdetails['jsdate'])
-            {
-                $showpicker = true;
-                break;
-            }
-        }
-        return $showpicker;
+        $dateformat = 0;
     }
-
-
-    function getLanguageCodefromLanguage($languagetosearch)
+    else
     {
-        $detaillanguages = getLanguageData(false,Yii::app()->session['adminlang']);
-        foreach ($detaillanguages as $key2=>$languagename)
+        $dateformat = (int) $data;
+    }
+    return (int) $dateformat;
+}
+
+
+/**
+ * Check whether we can show the JS date picker with the current format
+ *
+ * @param $dateformatdetails array Date format details for the question
+ * @param $dateformats array Available date formats
+ * @returns integer
+ *
+ */
+function canShowDatePicker($dateformatdetails, $dateformats=null)
+{
+    if(is_null($dateformats))
+    {
+        $dateformats = getDateFormatData();
+    }
+    $showpicker = false;
+    foreach($dateformats as $format)
+    {
+        if($format['jsdate'] == $dateformatdetails['jsdate'])
         {
-            if ($languagetosearch==$languagename['description'])
-            {
-                return $key2;
-            }
+            $showpicker = true;
+            break;
         }
+    }
+    return $showpicker;
+}
+
+
+function getLanguageCodefromLanguage($languagetosearch)
+{
+    $detaillanguages = getLanguageData(false,Yii::app()->session['adminlang']);
+    foreach ($detaillanguages as $key2=>$languagename)
+    {
+        if ($languagetosearch==$languagename['description'])
+        {
+            return $key2;
+        }
+    }
+    // else return default en code
+    return "en";
+}
+
+
+
+
+function getLanguageNameFromCode($codetosearch, $withnative=true, $sTranslationLanguage=null)
+{
+    if (is_null($sTranslationLanguage))
+    {
+        $sTranslationLanguage=Yii::app()->session['adminlang'];
+    }
+    $detaillanguages = getLanguageData(false,$sTranslationLanguage);
+    if (isset($detaillanguages[$codetosearch]['description']))
+    {
+        if ($withnative) {
+            return array($detaillanguages[$codetosearch]['description'], $detaillanguages[$codetosearch]['nativedescription']);
+        }
+        else { return $detaillanguages[$codetosearch]['description'];}
+    }
+    else
         // else return default en code
-        return "en";
-    }
+        return false;
+}
 
 
-
-
-    function getLanguageNameFromCode($codetosearch, $withnative=true, $sTranslationLanguage=null)
+function getLanguageRTL($sLanguageCode)
+{
+    $aLanguageData= getLanguageData(false,$sLanguageCode);
+    if (isset($aLanguageData[$sLanguageCode]['rtl']))
     {
-        if (is_null($sTranslationLanguage))
-        {
-            $sTranslationLanguage=Yii::app()->session['adminlang'];
-        }
-        $detaillanguages = getLanguageData(false,$sTranslationLanguage);
-        if (isset($detaillanguages[$codetosearch]['description']))
-        {
-            if ($withnative) {
-                return array($detaillanguages[$codetosearch]['description'], $detaillanguages[$codetosearch]['nativedescription']);
-            }
-            else { return $detaillanguages[$codetosearch]['description'];}
-        }
-        else
-            // else return default en code
-            return false;
+        return $aLanguageData[$sLanguageCode]['rtl'];
     }
-
-
-    function getLanguageRTL($sLanguageCode)
+    else
     {
-        $aLanguageData= getLanguageData(false,$sLanguageCode);
-        if (isset($aLanguageData[$sLanguageCode]['rtl']))
-        {
-            return $aLanguageData[$sLanguageCode]['rtl'];
-        }
-        else
-        {
-            return false;
-        }
+        return false;
     }
+}
 
-    /**
-    * Returns the locale settings for a certain language code
-    *
-    * @param string $codetosearch
-    * @return array Array with locale details
-    *
-    */
-    function getLanguageDetails($codetosearch)
+/**
+ * Returns the locale settings for a certain language code
+ *
+ * @param string $codetosearch
+ * @return array Array with locale details
+ *
+ */
+function getLanguageDetails($codetosearch)
+{
+    $detaillanguages = getLanguageData(false,Yii::app()->session['adminlang']);
+    if (isset($detaillanguages[$codetosearch]))
     {
-        $detaillanguages = getLanguageData(false,Yii::app()->session['adminlang']);
-        if (isset($detaillanguages[$codetosearch]))
-        {
-            return $detaillanguages[$codetosearch];
-        }
-        else
-        {
-            return $detaillanguages['en'];
+        return $detaillanguages[$codetosearch];
+    }
+    else
+    {
+        return $detaillanguages['en'];
+    }
+}
+
+function getLanguageDataRestricted($bOrderByNative=false,$sLanguageCode='en') {
+    $aLanguageData=getLanguageData($bOrderByNative, $sLanguageCode);
+
+    if (trim(Yii::app()->getConfig('restrictToLanguages'))!='')
+    {
+        foreach(explode(' ',trim(Yii::app()->getConfig('restrictToLanguages'))) AS $key) {
+            $aArray[$key] = $aLanguageData[$key];
         }
     }
-
-    function getLanguageDataRestricted($bOrderByNative=false,$sLanguageCode='en') {
-        $aLanguageData=getLanguageData($bOrderByNative, $sLanguageCode);
-
-        if (trim(Yii::app()->getConfig('restrictToLanguages'))!='')
-        {
-            foreach(explode(' ',trim(Yii::app()->getConfig('restrictToLanguages'))) AS $key) {
-                $aArray[$key] = $aLanguageData[$key];
-            }
-        }
-        else
-        {
-            $aArray=$aLanguageData;
-        }
-        return $aArray;
+    else
+    {
+        $aArray=$aLanguageData;
     }
+    return $aArray;
+}
 
 
-    function userSort($a, $b) {
+function userSort($a, $b) {
 
-        // smarts is all-important, so sort it first
-        if($a['description'] >$b['description']) {
-            return 1;
-        }
-        else {
-            return -1;
-        }
+    // smarts is all-important, so sort it first
+    if($a['description'] >$b['description']) {
+        return 1;
     }
-
-
-    function userSortNative($a, $b) {
-
-        // smarts is all-important, so sort it first
-        if($a['nativedescription'] >$b['nativedescription']) {
-            return 1;
-        }
-        else {
-            return -1;
-        }
+    else {
+        return -1;
     }
+}
 
 
-    /**
-    * This function  support the ability NOT to reverse numbers (for example when you output
-    * a phrase as a parameter for a SWF file that can't handle RTL languages itself, but
-    * obviously any numbers should remain the same as in the original phrase).
-    * Note that it can be used just as well for UTF-8 usages if you want the numbers to remain intact
-    *
-    * @param string $str
-    * @param boolean $reverse_numbers
-    * @return string
-    */
-    function UTF8Strrev($str, $reverse_numbers=false) {
-        preg_match_all('/./us', $str, $ar);
-        if ($reverse_numbers)
-            return join('',array_reverse($ar[0]));
-        else {
-            $temp = array();
-            foreach ($ar[0] as $value) {
-                if (is_numeric($value) && !empty($temp[0]) && is_numeric($temp[0])) {
-                    foreach ($temp as $key => $value2) {
-                        if (is_numeric($value2))
-                            $pos = ($key + 1);
-                        else
-                            break;
-                    }
-                    $temp2 = array_splice($temp, $pos);
-                    $temp = array_merge($temp, array($value), $temp2);
-                } else
-                    array_unshift($temp, $value);
-            }
-            return implode('', $temp);
-        }
+function userSortNative($a, $b) {
+
+    // smarts is all-important, so sort it first
+    if($a['nativedescription'] >$b['nativedescription']) {
+        return 1;
     }
+    else {
+        return -1;
+    }
+}
+
+
+/**
+ * This function  support the ability NOT to reverse numbers (for example when you output
+ * a phrase as a parameter for a SWF file that can't handle RTL languages itself, but
+ * obviously any numbers should remain the same as in the original phrase).
+ * Note that it can be used just as well for UTF-8 usages if you want the numbers to remain intact
+ *
+ * @param string $str
+ * @param boolean $reverse_numbers
+ * @return string
+ */
+function UTF8Strrev($str, $reverse_numbers=false) {
+    preg_match_all('/./us', $str, $ar);
+    if ($reverse_numbers)
+        return join('',array_reverse($ar[0]));
+    else {
+        $temp = array();
+        foreach ($ar[0] as $value) {
+            if (is_numeric($value) && !empty($temp[0]) && is_numeric($temp[0])) {
+                foreach ($temp as $key => $value2) {
+                    if (is_numeric($value2))
+                        $pos = ($key + 1);
+                    else
+                        break;
+                }
+                $temp2 = array_splice($temp, $pos);
+                $temp = array_merge($temp, array($value), $temp2);
+            } else
+                array_unshift($temp, $value);
+        }
+        return implode('', $temp);
+    }
+}
 
 ?>

--- a/upload/templates/ProofPilot_final/template.js
+++ b/upload/templates/ProofPilot_final/template.js
@@ -36,10 +36,10 @@ function focusFirst(Event)
 
 /* Uncomment below if you want to use the focusFirst function */
 /*
-$(document).ready(function(){
-	focusFirst();
-});
-*/
+ $(document).ready(function(){
+ focusFirst();
+ });
+ */
 
 
 
@@ -47,7 +47,7 @@ function correctPNG() // correctly handle PNG transparency in Win IE 5.5 & 6.
 {
     var arVersion = navigator.appVersion.split("MSIE")
     var version = parseFloat(arVersion[1])
-    if ((version >= 5.5) && (version < 7) && (document.body.filters)) 
+    if ((version >= 5.5) && (version < 7) && (document.body.filters))
     {
         for (var i = 0; i < document.images.length; i++)
         {
@@ -59,16 +59,16 @@ function correctPNG() // correctly handle PNG transparency in Win IE 5.5 & 6.
                 var imgClass = (img.className) ? "class='" + img.className + "' " : "";
                 var imgTitle = (img.title) ? "title='" + img.title + "' " : "title='" + img.alt + "' ";
                 var imgStyle = "display:inline-block;" + img.style.cssText;
-                if (img.align == "left") 
+                if (img.align == "left")
                     imgStyle = "float:left;" + imgStyle;
-                if (img.align == "right") 
+                if (img.align == "right")
                     imgStyle = "float:right;" + imgStyle;
-                if (img.parentElement.href) 
+                if (img.parentElement.href)
                     imgStyle = "cursor:hand;" + imgStyle;
                 var strNewHTML = "<span " + imgID + imgClass + imgTitle
-                + " style=\"" + "width:" + img.width + "px; height:" + img.height + "px;" + imgStyle + ";"
-                + "filter:progid:DXImageTransform.Microsoft.AlphaImageLoader"
-                + "(src='" + img.src + "', sizingMethod='scale');\"></span>" 
+                    + " style=\"" + "width:" + img.width + "px; height:" + img.height + "px;" + imgStyle + ";"
+                    + "filter:progid:DXImageTransform.Microsoft.AlphaImageLoader"
+                    + "(src='" + img.src + "', sizingMethod='scale');\"></span>"
                 img.outerHTML = strNewHTML
                 i = i-1
             }
@@ -76,21 +76,25 @@ function correctPNG() // correctly handle PNG transparency in Win IE 5.5 & 6.
     }
 }
 
-$(document).ready(function() {
-
-    //Check for input errors
-    $("div[id^='question']").each(function() {
-        if ( $(this).hasClass("input-error") ) {
+function errorNotification(questiondiv){
+    if (!$("#surveydata").siblings('div').hasClass('notification')) {
+        if (questiondiv.hasClass("input-error")) {
 
             $("#surveydata").after("<div class='notification'><div class='error-notification'>*Please scroll down to see items needing attention.* <!--<br/> <a href='javascript:void(0);' onClick='goToFirstInputError();'>Click here to go to the first item.</a>--></div></div>");
 
-            if ( $("td.notification").length > 0 ) {
+            if ($("td.notification").length > 0) {
                 $("html, body").animate({
-                    scrollTop: $(".notification").offset().top 
+                    scrollTop: $(".notification").offset().top
                 }, 1000);
             }
             return false;
         }
+    }
+}
+
+$(document).ready(function() {
+    $("div[id^='question']").each(function() {
+        errorNotification($(this));
 
     });
 
@@ -120,18 +124,18 @@ $(document).ready(function() {
 
     $("#answer187572X765X8001").bind("change paste keyup", function() {
         var strollers = $(this).val();
-        if (strollers > 10) 
+        if (strollers > 10)
             strollers = 10;
 
         hideallstrollers();
 
-        if (strollers >= 1) 
+        if (strollers >= 1)
             $("#question7989").show();
 
         for (i = 1; i <= strollers; i++) {
-            if (i <= 9) 
+            if (i <= 9)
                 $("#javatbd187572X765X7989SQ00" + i).show();
-            else 
+            else
                 $("#javatbd187572X765X7989SQ0" + i).show();
         }
     });
@@ -170,15 +174,15 @@ $(document).ready(function() {
 
     var brands = getdigits(content);
 
-    if (brands > 10) 
+    if (brands > 10)
         brands = 10;
 
     hideallBrandAwareness();
 
     for (i = 1; i <= brands; i++) {
-        if (i <= 9) 
+        if (i <= 9)
             $("#javatbd187572X766X8002SQ00" + i).show();
-        else 
+        else
             $("#javatbd187572X766X8002SQ0" + i).show();
     }
 });
@@ -374,7 +378,7 @@ $( document ).ready(function() {
                 update7166($('label[for=answer272135X714X7165A6]').text());
             });
             $('#SOTH272135X714X7165').click(function() {
-                update7166("Your above answer (7166)") 
+                update7166("Your above answer (7166)")
             });
 
             $('#answer272135X714X7165othertext').keyup(function () {
@@ -396,7 +400,6 @@ $( document ).ready(function() {
     });
 
 });
-
 
 
 

--- a/upload/templates/ProofPilot_final/template_full.css
+++ b/upload/templates/ProofPilot_final/template_full.css
@@ -1,7 +1,7 @@
-                                                                                                                                                                                                                /*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
 /* START: CSS reset */
 html,body,div,dl,dt,dd,ul,p,blockquote,pre,th,td,
-  form,fieldset,input,textarea {
+form,fieldset,input,textarea {
   margin:0;
   padding:0;
 }
@@ -9,7 +9,7 @@ table {
   border-collapse:collapse;
   border-spacing:0;
 }
-fieldset,img,abbr,acronym { 
+fieldset,img,abbr,acronym {
   border:0;
 }
 ol,ul {
@@ -74,19 +74,19 @@ h3 {
 }
 
 a:link, a:visited {
-color: #bc3d34;
-text-decoration: underline;
+  color: #bc3d34;
+  text-decoration: underline;
 }
 a:hover, a:focus {
-text-decoration: none;
+  text-decoration: none;
 }
 
 a.upload:link, a.upload:visited {
-color: #6f6f6f;
-text-decoration: underline;
+  color: #6f6f6f;
+  text-decoration: underline;
 }
 a.upload:hover, a.upload:focus {
-text-decoration: none;
+  text-decoration: none;
 }
 
 .hide {
@@ -94,17 +94,17 @@ text-decoration: none;
 }
 
 textarea {
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 400;
-	color: #6f6f6f;
-	font-size: 13px;
-	line-height: 29px;
-	background: white;
-	border: 1px solid #c9c9c9;
-	border-radius: 3px;
-	text-align: left;
-	padding: 0 10px;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  color: #6f6f6f;
+  font-size: 13px;
+  line-height: 29px;
+  background: white;
+  border: 1px solid #c9c9c9;
+  border-radius: 3px;
+  text-align: left;
+  padding: 0 10px;
 }
 /* END: General layout */
 /*----------------------------------------------------------------------------*/
@@ -116,25 +116,25 @@ textarea {
 /*----------------------------------------------------------------------------*/
 /* START: Centered vertical alignment */
 #surveylist,
-  #surveyinfo, #privacynote,
-  #surveydata,
-  #register,
-  #load, #save,
-  .printouttitle, .printouttable th,
-  .groupname, .groupdescription,
-  p.captcha,
-  #tokenform ul li {
+#surveyinfo, #privacynote,
+#surveydata,
+#register,
+#load, #save,
+.printouttitle, .printouttable th,
+.groupname, .groupdescription,
+p.captcha,
+#tokenform ul li {
   text-align:center;
 }
 table.register,
-  #load table, #save table {
+#load table, #save table {
   margin:0 auto;
 }
 
 
 /* Answertext alignment (important when questions only are aligned left) */
 .numeric-multi .answer ul li label,
-  .multiple-short-txt .answer ul li label {
+.multiple-short-txt .answer ul li label {
   text-align:left;
 }
 /* END: Centered vertical alignment */
@@ -191,11 +191,11 @@ table.register,
 
 #panel_left #content {
   color: #7e7e7e;
-  font-size: 13px; 
+  font-size: 13px;
 }
 
 #panel_left #content p {
-  margin-bottom: 15px; 
+  margin-bottom: 15px;
 }
 
 #panel_left #about {
@@ -208,7 +208,7 @@ table.register,
   padding-left: 22px;
   margin: -25px 0px 25px -24px;
   width: 242px;
-  
+
   font-weight: 700;
   font-style: normal;
 }
@@ -252,7 +252,7 @@ table.register,
 /*----------------------------------------------------------------------------*/
 /* Headings */
 #surveylist h1, #surveyinfo h1, #surveydata h1, .printouttitle,
-  #load h1, #save h1 {}
+#load h1, #save h1 {}
 /*----------------------------------------------------------------------------*/
 
 
@@ -262,15 +262,15 @@ table.register,
 /*----------------------------------------------------------------------------*/
 /* Buttons */
 #loadbutton, #savebutton,
-  input.submit,
-  .clearall, .saveall,
-  .date p.question button.ui-datepicker-triggert {
+input.submit,
+.clearall, .saveall,
+.date p.question button.ui-datepicker-triggert {
   padding:1px 4px;
 }
 
 #registercontinue,
-  #loadbutton, #savebutton,
-  #tokenform input.submit {
+#loadbutton, #savebutton,
+#tokenform input.submit {
   /* To use, when button bg-color is same as navigator container bg-color,
   but not page bg-color */
 }
@@ -391,7 +391,7 @@ table.register,
   margin:20px 12% 0;
   background-color:#fff;
 }
-.assessmentheading {  
+.assessmentheading {
   font-weight:700;
   background-color:#ccc;
   padding:3px;
@@ -406,7 +406,7 @@ table.register,
   padding:3px;
 }
 #assessments table td {;
-    padding:3px;
+  padding:3px;
 }
 
 
@@ -435,30 +435,30 @@ table.register,
 
 
 /*#clearall {*/
-  /*margin:20px 12%;*/
-  /*border:1px solid #111;*/
-  /*padding:10px;*/
-  /*text-align:center;*/
+/*margin:20px 12%;*/
+/*border:1px solid #111;*/
+/*padding:10px;*/
+/*text-align:center;*/
 /*}*/
 /*#clearall span.answerscleared {*/
-  /*color:#ff0f0f;*/
-  /*font-weight:700;*/
-  /*font-size:110%;*/
+/*color:#ff0f0f;*/
+/*font-weight:700;*/
+/*font-size:110%;*/
 /*}*/
 /*#clearall{*/
-  /*font-size: 15px;*/
-  /*line-height: 42px;*/
-  /*height: 42px;*/
-  /*padding-right: 25px;*/
-  /*padding-left: 25px;*/
-  /*border: 1px solid #61a9c5;*/
-  /*background: rgb(157,196,210);*/
-  /*background: -moz-linear-gradient(top, rgba(157,196,210,1) 0%, rgba(119,159,174,1) 100%);*/
-  /*background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(157,196,210,1)), color-stop(100%,rgba(119,159,174,1)));*/
-  /*background: -webkit-linear-gradient(top, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
-  /*background: -o-linear-gradient(top, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
-  /*background: -ms-linear-gradient(top, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
-  /*background: linear-gradient(to bottom, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
+/*font-size: 15px;*/
+/*line-height: 42px;*/
+/*height: 42px;*/
+/*padding-right: 25px;*/
+/*padding-left: 25px;*/
+/*border: 1px solid #61a9c5;*/
+/*background: rgb(157,196,210);*/
+/*background: -moz-linear-gradient(top, rgba(157,196,210,1) 0%, rgba(119,159,174,1) 100%);*/
+/*background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(157,196,210,1)), color-stop(100%,rgba(119,159,174,1)));*/
+/*background: -webkit-linear-gradient(top, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
+/*background: -o-linear-gradient(top, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
+/*background: -ms-linear-gradient(top, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
+/*background: linear-gradient(to bottom, rgba(157,196,210,1) 0%,rgba(119,159,174,1) 100%);*/
 /*}*/
 #clearall {
   padding:10px;
@@ -587,9 +587,9 @@ table.register td input.text { /* input form fields */
 /*----------------------------------------------------------------------------*/
 /* Public Statistics */
 #statsContainer { /* Container */
- 	border-top: 52px solid #87b31d;
+  border-top: 52px solid #87b31d;
   margin: 0;
-	width: 100%;
+  width: 100%;
   max-width: 738px !important;
 }
 #statsContainer .statsSurveyTitle { /* Main Title */
@@ -609,21 +609,21 @@ table.register td input.text { /* input form fields */
 
 #statsContainer .statsSurveyTitle {
   padding: 0;
-	color: #4a4a4a;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 28px;
-	text-align: center;
-	margin-bottom: 10px;
+  color: #4a4a4a;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 28px;
+  text-align: center;
+  margin-bottom: 10px;
 }
 
 .statsNumRecords {
   text-align: center;
-	color: #4a4a4a;
-	font-size: 13px;
-	line-height: 150%;
-	margin-bottom: 20px;
+  color: #4a4a4a;
+  font-size: 13px;
+  line-height: 150%;
+  margin-bottom: 20px;
 }
 
 div.fieldSummary {
@@ -643,27 +643,27 @@ table.statisticstable {
   margin:5px auto 20px;
 }
 table.statisticstable {
-	width: 100%;
+  width: 100%;
   margin: 0;
   border-top: 1px solid #BBC6CC;
 }
 table.statisticstable td {
-	width: 100%;
+  width: 100%;
   max-width: 698px !important;
   line-height: 190%;
   border-bottom: 1px solid #BBC6CC;
- 	text-align: center;
-	padding: 2px 20px;
+  text-align: center;
+  padding: 2px 20px;
 }
 
 table.statisticstable th {
-	text-align: center;
-	padding: 10px 0;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 15px;
-	padding: 10px 20px;
+  text-align: center;
+  padding: 10px 0;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  padding: 10px 20px;
 }
 
 table.statisticstable img {
@@ -672,20 +672,20 @@ table.statisticstable img {
 }
 
 table.statisticssummary {
-	margin: 0 0 20px 20px;
+  margin: 0 0 20px 20px;
 }
 
 table.statisticssummary thead tr th {
-	font-family: 'Roboto', sans-serif;
-	color: #bc3d34;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 17px;
-	padding-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+  color: #bc3d34;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 17px;
+  padding-bottom: 10px;
 }
 
 table.statisticssummary tbody tr th {
-	padding-right: 10px;
+  padding-right: 10px;
 }
 
 
@@ -720,7 +720,7 @@ table.statisticssummary tbody tr th {
 
 
 .question-wrapper {
-	margin-right: 0;
+  margin-right: 0;
   margin-bottom: 20px;
   background: #faf9f1;
   border: 1px solid #dfded5;
@@ -728,7 +728,7 @@ table.statisticssummary tbody tr th {
   padding: 20px 20px 0px 20px;
   width: 632px;
   width: 100%;
-  max-width: 632px;   
+  max-width: 632px;
 }
 
 
@@ -766,22 +766,22 @@ div.answer {
   font-size: 13px;
 }
 .date .answer,
-  .gender .answer,
-  .numeric .answer,
-  .numeric-multi .answer,
-  .ranking .answer,
-  .yes-no .answer,
-  .language .answer,
-  .multiple-opt .answer,
-  .multiple-opt-comments .answer,
-  .list-dropdown .answer,
-  .choice-5-pt-radio .answer,
-  .list-radio .answer,
-  .list-with-comment .answer,
-  .multiple-short-txt .answer,
-  .text-short .answer,
-  .text-long .answer,
-  .text-huge .answer { /* applies to all question types but array */
+.gender .answer,
+.numeric .answer,
+.numeric-multi .answer,
+.ranking .answer,
+.yes-no .answer,
+.language .answer,
+.multiple-opt .answer,
+.multiple-opt-comments .answer,
+.list-dropdown .answer,
+.choice-5-pt-radio .answer,
+.list-radio .answer,
+.list-with-comment .answer,
+.multiple-short-txt .answer,
+.text-short .answer,
+.text-long .answer,
+.text-huge .answer { /* applies to all question types but array */
 }
 
 
@@ -798,22 +798,22 @@ div.questionhelp img {
   vertical-align:middle;
 }
 .date div.questionhelp,
-  .gender  div.questionhelp,
-  .numeric  div.questionhelp,
-  .numeric-multi  div.questionhelp,
-  .ranking  div.questionhelp,
-  .yes-no  div.questionhelp,
-  .language  div.questionhelp,
-  .multiple-opt  div.questionhelp,
-  .multiple-opt-comments  div.questionhelp,
-  .list-dropdown  div.questionhelp,
-  .choice-5-pt-radio  div.questionhelp,
-  .list-radio  div.questionhelp,
-  .list-with-comment  div.questionhelp,
-  .multiple-short-txt  div.questionhelp,
-  .text-short  div.questionhelp,
-  .text-long  div.questionhelp,
-  .text-huge  div.questionhelp { /* applies to all question types but array */
+.gender  div.questionhelp,
+.numeric  div.questionhelp,
+.numeric-multi  div.questionhelp,
+.ranking  div.questionhelp,
+.yes-no  div.questionhelp,
+.language  div.questionhelp,
+.multiple-opt  div.questionhelp,
+.multiple-opt-comments  div.questionhelp,
+.list-dropdown  div.questionhelp,
+.choice-5-pt-radio  div.questionhelp,
+.list-radio  div.questionhelp,
+.list-with-comment  div.questionhelp,
+.multiple-short-txt  div.questionhelp,
+.text-short  div.questionhelp,
+.text-long  div.questionhelp,
+.text-huge  div.questionhelp { /* applies to all question types but array */
 }
 /* END: Question parts */
 /*----------------------------------------------------------------------------*/
@@ -824,18 +824,18 @@ div.questionhelp img {
 
 /* START: Navigator */
 #navigator {
-clear: both;
-float: left;
-margin: 0;
-padding: 0;
-background: #f8f8f8;
-border-top: 1px solid #cfcfcf;
-padding: 35px 30px 0 30px;
-margin-top: 30px;
-height: 91px;
-width: 100%;
-max-width: 678px;
-bottom: 0;
+  clear: both;
+  float: left;
+  margin: 0;
+  padding: 0;
+  background: #f8f8f8;
+  border-top: 1px solid #cfcfcf;
+  padding: 35px 30px 0 30px;
+  margin-top: 30px;
+  height: 91px;
+  width: 100%;
+  max-width: 678px;
+  bottom: 0;
 }
 #navigator #left {
   float:left;
@@ -858,238 +858,238 @@ bottom: 0;
 /* Submit buttons */
 
 .submit, input.submit {
-height: 42px;
-font-size: 15px;
-margin: 0px;
-margin-left: 10px;
-color: #FFFFFF !important;
-border: 1px solid #7ea61f;
-background: #97c42c;
-background: -moz-linear-gradient(top, #97c42c 0%, #7fa71f 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #97c42c), color-stop(100%,#7fa71f));
-background: -webkit-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
-background: -o-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
-background: -ms-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
-background: linear-gradient(to bottom, #97c42c 0%,#7fa71f 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#97c42c', endColorstr='#7fa71f',GradientType=0 );
-display: inline-block;
-font-family: 'Roboto', 'sans-serif';
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;
+  height: 42px;
+  font-size: 15px;
+  margin: 0px;
+  margin-left: 10px;
+  color: #FFFFFF !important;
+  border: 1px solid #7ea61f;
+  background: #97c42c;
+  background: -moz-linear-gradient(top, #97c42c 0%, #7fa71f 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #97c42c), color-stop(100%,#7fa71f));
+  background: -webkit-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
+  background: -o-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
+  background: -ms-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
+  background: linear-gradient(to bottom, #97c42c 0%,#7fa71f 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#97c42c', endColorstr='#7fa71f',GradientType=0 );
+  display: inline-block;
+  font-family: 'Roboto', 'sans-serif';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
 }
 
 .submit:hover, input.submit:hover {
-border: 1px solid #608016;
-background: #6e8f20;
-background: -moz-linear-gradient(top, #6e8f20 0%, #5d7a17 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8f20), color-stop(100%,#5d7a17));
-background: -webkit-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
-background: -o-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
-background: -ms-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
-background: linear-gradient(to bottom, #6e8f20 0%,#5d7a17 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8f20', endColorstr='#5d7a17',GradientType=0 );
+  border: 1px solid #608016;
+  background: #6e8f20;
+  background: -moz-linear-gradient(top, #6e8f20 0%, #5d7a17 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8f20), color-stop(100%,#5d7a17));
+  background: -webkit-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
+  background: -o-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
+  background: -ms-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
+  background: linear-gradient(to bottom, #6e8f20 0%,#5d7a17 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8f20', endColorstr='#5d7a17',GradientType=0 );
 }
 
 /* Move next & prev buttons */
 
 #movenextbtn {
-height: 42px;
-font-size: 15px;
-line-height: 42px;
-margin: 0px;
-color: #484444 !important;
-border: 1px solid #d3d3d3;
-background: #f5f5f5;
-background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
-background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
-margin-left: 10px;
-padding-left: 25px;
-padding-right: 25px;
+  height: 42px;
+  font-size: 15px;
+  line-height: 42px;
+  margin: 0px;
+  color: #484444 !important;
+  border: 1px solid #d3d3d3;
+  background: #f5f5f5;
+  background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
+  background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
+  margin-left: 10px;
+  padding-left: 25px;
+  padding-right: 25px;
 }
 
 #movenextbtn:hover {
-border-color: #b5b5b5;
-background: #c7c7c7;
-background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
-background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
+  border-color: #b5b5b5;
+  background: #c7c7c7;
+  background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
+  background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
 }
 
 .ui-button-text-icon-secondary .ui-button-text, .ui-button-text-icons .ui-button-text {
-background: url(icon_next.png) no-repeat  100% 50%;
-background-size: 9px 13px;
-padding: 0;
-padding-right: 25px;
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;
+  background: url(icon_next.png) no-repeat  100% 50%;
+  background-size: 9px 13px;
+  padding: 0;
+  padding-right: 25px;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
 }
 
 .ui-state-default .ui-icon {
-	background: none;
-	display: none;
+  background: none;
+  display: none;
 }
 
 #moveprevbtn {
-height: 42px;
-font-size: 15px;
-line-height: 42px;
-margin: 0px;
-color: #484444 !important;
-border: 1px solid #d3d3d3;
-background: #f5f5f5;
-background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
-background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
-padding: 0 25px;	
+  height: 42px;
+  font-size: 15px;
+  line-height: 42px;
+  margin: 0px;
+  color: #484444 !important;
+  border: 1px solid #d3d3d3;
+  background: #f5f5f5;
+  background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
+  background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
+  padding: 0 25px;
 }
 
 #moveprevbtn:hover {
-border-color: #b5b5b5;
-background: #c7c7c7;
-background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
-background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
+  border-color: #b5b5b5;
+  background: #c7c7c7;
+  background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
+  background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
 }
 
 .ui-button-text-icon-primary .ui-button-text, .ui-button-text-icons .ui-button-text {
-background: url(icon_back.png) no-repeat  0% 50%;
-background-size: 9px 13px;
-padding: 0;
-padding-left: 25px;
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;	
+  background: url(icon_back.png) no-repeat  0% 50%;
+  background-size: 9px 13px;
+  padding: 0;
+  padding-left: 25px;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
 }
 
 /* Save All button */
 .saveall {
-height: 42px;
-font-size: 15px;
-margin: 0px;
-color: #FFF !important;
-border: 1px solid #64adc9;
-background: #9ec5d3;
-background: -moz-linear-gradient(top, #9ec5d3 0%, #769ead 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#9ec5d3), color-stop(100%,#769ead));
-background: -webkit-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
-background: -o-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
-background: -ms-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
-background: linear-gradient(to bottom, #9ec5d3 0%,#769ead 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#9ec5d3', endColorstr='#769ead',GradientType=0 );
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;
+  height: 42px;
+  font-size: 15px;
+  margin: 0px;
+  color: #FFF !important;
+  border: 1px solid #64adc9;
+  background: #9ec5d3;
+  background: -moz-linear-gradient(top, #9ec5d3 0%, #769ead 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#9ec5d3), color-stop(100%,#769ead));
+  background: -webkit-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
+  background: -o-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
+  background: -ms-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
+  background: linear-gradient(to bottom, #9ec5d3 0%,#769ead 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#9ec5d3', endColorstr='#769ead',GradientType=0 );
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
 }
 
 .saveall:hover {
-border-color: #558ca2;
-background: #6e8993;
-background: -moz-linear-gradient(top, #6e8993 0%, #526e79 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8993), color-stop(100%,#526e79));
-background: -webkit-linear-gradient(top, #6e8993 0%,#526e79 100%);
-background: -o-linear-gradient(top, #6e8993 0%,#526e79 100%);
-background: -ms-linear-gradient(top, #6e8993 0%,#526e79 100%);
-background: linear-gradient(to bottom, #6e8993 0%,#526e79 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8993', endColorstr='#526e79',GradientType=0 );
+  border-color: #558ca2;
+  background: #6e8993;
+  background: -moz-linear-gradient(top, #6e8993 0%, #526e79 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8993), color-stop(100%,#526e79));
+  background: -webkit-linear-gradient(top, #6e8993 0%,#526e79 100%);
+  background: -o-linear-gradient(top, #6e8993 0%,#526e79 100%);
+  background: -ms-linear-gradient(top, #6e8993 0%,#526e79 100%);
+  background: linear-gradient(to bottom, #6e8993 0%,#526e79 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8993', endColorstr='#526e79',GradientType=0 );
 }
 
 /* Clear All button */
 .clearall {
-height: 42px;
-font-size: 15px;
-margin: 0px;
-color: #FFF !important;
-border: 1px solid #6e6e6e;
-background: #7c7e7d;
-background: -moz-linear-gradient(top, #7c7e7d 0%, #5c5d5f 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#7c7e7d), color-stop(100%,#5c5d5f));
-background: -webkit-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
-background: -o-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
-background: -ms-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
-background: linear-gradient(to bottom, #7c7e7d 0%,#5c5d5f 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#7c7e7d', endColorstr='#5c5d5f',GradientType=0 );
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;
+  height: 42px;
+  font-size: 15px;
+  margin: 0px;
+  color: #FFF !important;
+  border: 1px solid #6e6e6e;
+  background: #7c7e7d;
+  background: -moz-linear-gradient(top, #7c7e7d 0%, #5c5d5f 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#7c7e7d), color-stop(100%,#5c5d5f));
+  background: -webkit-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
+  background: -o-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
+  background: -ms-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
+  background: linear-gradient(to bottom, #7c7e7d 0%,#5c5d5f 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#7c7e7d', endColorstr='#5c5d5f',GradientType=0 );
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
 }
 
 .clearall:hover {
-border-color: #6e6e6e;
-background: #5e605f;
-background: -moz-linear-gradient(top, #5e605f 0%, #464748 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#5e605f), color-stop(100%,#464748));
-background: -webkit-linear-gradient(top, #5e605f 0%,#464748 100%);
-background: -o-linear-gradient(top, #5e605f 0%,#464748 100%);
-background: -ms-linear-gradient(top, #5e605f 0%,#464748 100%);
-background: linear-gradient(to bottom, #5e605f 0%,#464748 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5e605f', endColorstr='#464748',GradientType=0 );
+  border-color: #6e6e6e;
+  background: #5e605f;
+  background: -moz-linear-gradient(top, #5e605f 0%, #464748 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#5e605f), color-stop(100%,#464748));
+  background: -webkit-linear-gradient(top, #5e605f 0%,#464748 100%);
+  background: -o-linear-gradient(top, #5e605f 0%,#464748 100%);
+  background: -ms-linear-gradient(top, #5e605f 0%,#464748 100%);
+  background: linear-gradient(to bottom, #5e605f 0%,#464748 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5e605f', endColorstr='#464748',GradientType=0 );
 }
 
 /* Export-Button */
 
 #exportbutton {
-height: 42px;
-font-size: 15px;
-font-weight: 700;
-line-height: 42px;
-margin: 0px;
-color: #484444 !important;
-border: 1px solid #d3d3d3;
-background: #f5f5f5;
-background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
-background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
-padding: 0 25px;
-margin-top: 20px;
+  height: 42px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 42px;
+  margin: 0px;
+  color: #484444 !important;
+  border: 1px solid #d3d3d3;
+  background: #f5f5f5;
+  background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
+  background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
+  padding: 0 25px;
+  margin-top: 20px;
 }
 
 #exportbutton:hover {
-	cursor: pointer;
-border-color: #b5b5b5;
-background: #c7c7c7;
-background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
-background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
+  cursor: pointer;
+  border-color: #b5b5b5;
+  background: #c7c7c7;
+  background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
+  background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
 }
 
 
@@ -1123,13 +1123,13 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', end
 }
 #progress-pre {}
 #progressbar.ui-progressbar.ui-widget.ui-widget-content.ui-corner-all {
-  
+
   background: #658716;
   border: 1px solid #4f6a11;
   border-radius:8px;
   width: 250px;
   height: 10px;
-  
+
   -moz-box-shadow:    inset  0 1px 5px #4f6a11;
   -webkit-box-shadow: inset  0 1px 5px #4f6a11;
   box-shadow:         inset 0 1px 5px #4f6a11;
@@ -1140,7 +1140,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', end
   border: 1px solid #666;
   border-radius: 8px;
   background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#FFFFFF), to(#edf3f4));
-  background: -webkit-linear-gradient(top, #FFFFFF, #edf3f4); 
+  background: -webkit-linear-gradient(top, #FFFFFF, #edf3f4);
   background: -moz-linear-gradient(top, #FFFFFF, #edf3f4);
   background: -ms-linear-gradient(top, #FFFFFF, #edf3f4);
   background: -o-linear-gradient(top, #FFFFFF, #edf3f4);
@@ -1164,13 +1164,13 @@ select.languagechanger {}
 
 .printouttitle { /* see h1 */
   display:block;
-	color: #4a4a4a;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 28px;
-	text-align: center;
-	margin: 20px 0;
+  color: #4a4a4a;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 28px;
+  text-align: center;
+  margin: 20px 0;
 }
 
 .printouttable {}
@@ -1188,35 +1188,35 @@ select.languagechanger {}
 }
 
 tr.printanswersgroup {
-	font-family: 'Roboto', sans-serif;
-	color: #bc3d34;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 17px;
-	text-align: center;
+  font-family: 'Roboto', sans-serif;
+  color: #bc3d34;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 17px;
+  text-align: center;
 }
 
 tr.printanswersgroup td {
-		padding: 30px 0 10px 0;
-		border: 0;
+  padding: 30px 0 10px 0;
+  border: 0;
 }
 
 tr.printanswersquestionhead {
-	font-family: 'Roboto', sans-serif;
-	color: #4a4a4a;
-	font-style: normal;
-	font-weight: 700;
-	margin-bottom: 20px;
-	text-align: center;
+  font-family: 'Roboto', sans-serif;
+  color: #4a4a4a;
+  font-style: normal;
+  font-weight: 700;
+  margin-bottom: 20px;
+  text-align: center;
 }
 
 tr.printanswersquestionhead td {
-	border: 0;
-	padding: 15px 0 2px 0;
+  border: 0;
+  padding: 15px 0 2px 0;
 }
 
 tr.printanswersquestion td {
-	border-left: 0;
+  border-left: 0;
 }
 
 
@@ -1254,7 +1254,7 @@ p#tokenmessage {
 #tokenform ul li input#token {}
 #tokenform ul li img#captchaimage {}
 #token,
-  #captchaimage {
+#captchaimage {
   margin:3px 5px;
 }
 #tokenform ul li input.submit {}
@@ -1279,26 +1279,26 @@ span.asterisk { /* Asterisk when question mandatory */
 
 /* ul in table style */
 .numeric-multi .answer ul,
-  .multiple-opt-comments .answer ul,
-  .multiple-short-txt .answer ul {
+.multiple-opt-comments .answer ul,
+.multiple-short-txt .answer ul {
   display:table;
 }
 .numeric-multi .answer ul li,
-  .multiple-opt-comments .answer ul li,
-  .multiple-short-txt .answer ul li {
+.multiple-opt-comments .answer ul li,
+.multiple-short-txt .answer ul li {
   display:table-row;
 }
 .numeric-multi .answer ul li label,
-  .numeric-multi .answer ul li span.input,
-  .numeric-multi .answer ul li.multiplenumerichelp span,
-  .numeric-multi .answer ul li div.slider_lefttext,
-  .numeric-multi .answer ul li label.slider-label,
-  .numeric-multi .answer ul li div.multinum-slider,
-  .numeric-multi .answer ul li div.slider_righttext,
-  .multiple-opt-comments .answer ul li span.option,
-  .multiple-opt-comments .answer ul li span.comment,
-  .multiple-short-txt .answer ul li label,
-  .multiple-short-txt .answer ul li span {
+.numeric-multi .answer ul li span.input,
+.numeric-multi .answer ul li.multiplenumerichelp span,
+.numeric-multi .answer ul li div.slider_lefttext,
+.numeric-multi .answer ul li label.slider-label,
+.numeric-multi .answer ul li div.multinum-slider,
+.numeric-multi .answer ul li div.slider_righttext,
+.multiple-opt-comments .answer ul li span.option,
+.multiple-opt-comments .answer ul li span.comment,
+.multiple-short-txt .answer ul li label,
+.multiple-short-txt .answer ul li span {
   display:table-cell;
   vertical-align:middle;
 }
@@ -1311,14 +1311,14 @@ span.asterisk { /* Asterisk when question mandatory */
 /* end correction */
 
 .numeric-multi .answer ul li label,
-  .multiple-opt-comments .answer ul li span.option,
-  .multiple-short-txt .answer ul li label {
+.multiple-opt-comments .answer ul li span.option,
+.multiple-short-txt .answer ul li label {
   padding:3px 10px 3px 0;
 }
 .numeric-multi .answer ul li span.input,
-  .numeric-multi .answer ul li.multiplenumerichelp span,
-  .multiple-opt-comments .answer ul li span.comment,
-  .multiple-short-txt .answer ul li span { /* compare with padding of table answertext */
+.numeric-multi .answer ul li.multiplenumerichelp span,
+.multiple-opt-comments .answer ul li span.comment,
+.multiple-short-txt .answer ul li span { /* compare with padding of table answertext */
   padding:3px;
 }
 
@@ -1326,81 +1326,81 @@ span.asterisk { /* Asterisk when question mandatory */
 
 /* All input form fields (careful with background-color !) */
 input.text,
-  .array-multi-flexi-text tbody td label input,
-  .array-multi-flexi tbody td input,
-  .date p.question input,
-  .numeric-multi li.multiplenumerichelp input.good,
-  .numeric-multi li.multiplenumerichelp input.problem,
-  .numeric-multi .answer ul li span.input input {
-	height: 29px;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 400;
-	color: #6f6f6f;
-	font-size: 13px;
-	line-height: 29px;
-	background: white;
-	border: 1px solid #c9c9c9;
-	border-radius: 3px;
-	text-align: left;
-	padding: 0 10px;
+.array-multi-flexi-text tbody td label input,
+.array-multi-flexi tbody td input,
+.date p.question input,
+.numeric-multi li.multiplenumerichelp input.good,
+.numeric-multi li.multiplenumerichelp input.problem,
+.numeric-multi .answer ul li span.input input {
+  height: 29px;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  color: #6f6f6f;
+  font-size: 13px;
+  line-height: 29px;
+  background: white;
+  border: 1px solid #c9c9c9;
+  border-radius: 3px;
+  text-align: left;
+  padding: 0 10px;
 }
 
 p.question.answer-item.text-item.inputwidth-15.withprefix.withsuffix input.text {
-	margin: 0 20px;
+  margin: 0 20px;
 }
 
 p.question.question.answer-item.text-item.numeric-item.withprefix input.text {
-	margin: 0 20px;
+  margin: 0 20px;
 }
 
 
 /* Hovereffect in text form fields and areas */
 input.text:focus,
-  .array-multi-flexi-text tbody td label input:focus,
-  .array-multi-flexi tbody td input:focus,
-  .date p.question input:focus,
-  .numeric-multi .answer ul li span.input input:focus,
-  .textarea:focus {
+.array-multi-flexi-text tbody td label input:focus,
+.array-multi-flexi tbody td input:focus,
+.date p.question input:focus,
+.numeric-multi .answer ul li span.input input:focus,
+.textarea:focus {
   background-color:#FFF;
 }
 
 
 /* Right align of text in numeric question types*/
 .numeric p.question input.text,
-  .numeric-multi li.multiplenumerichelp input,
-  .numeric-multi .answer ul li span.input input {
+.numeric-multi li.multiplenumerichelp input,
+.numeric-multi .answer ul li span.input input {
   text-align:right;
 }
 
 
 /* Alignment of checkbox/radio and text following it */
 .gender .answer ul li,
-  .yes-no .answer ul li,
-  .multiple-opt .answer ul li,
-  .choice-5-pt-radio .answer ul li,
-  .list-radio .answer ul li,
-  .list-with-comment .answer .list ul li  {
+.yes-no .answer ul li,
+.multiple-opt .answer ul li,
+.choice-5-pt-radio .answer ul li,
+.list-radio .answer ul li,
+.list-with-comment .answer .list ul li  {
   position:relative;
   margin-bottom:15px;
   text-align:left;
 }
 .gender .answer ul li input.radio,
-  .yes-no .answer ul li input.radio,
-  .multiple-opt .answer ul li input.checkbox,
-  .choice-5-pt-radio .answer ul li input.radio,
-  .list-radio .answer ul li input.radio,
-  .list-with-comment .answer .list ul li input.radio {
+.yes-no .answer ul li input.radio,
+.multiple-opt .answer ul li input.checkbox,
+.choice-5-pt-radio .answer ul li input.radio,
+.list-radio .answer ul li input.radio,
+.list-with-comment .answer .list ul li input.radio {
   position:absolute;
   top:1px;
   left:0;
 }
 .gender .answer ul li label.answertext,
-  .yes-no .answer ul li label.answertext,
-  .multiple-opt .answer ul li label.answertext,
-  .choice-5-pt-radio .answer ul li label.answertext,
-  .list-radio .answer ul li label.answertext,
-  .list-with-comment .answer .list ul li label.answertext {
+.yes-no .answer ul li label.answertext,
+.multiple-opt .answer ul li label.answertext,
+.choice-5-pt-radio .answer ul li label.answertext,
+.list-radio .answer ul li label.answertext,
+.list-with-comment .answer .list ul li label.answertext {
   display:inline-block;
   margin-left:20px;
 }
@@ -1417,8 +1417,8 @@ input.text:focus,
 
 
 .gender .answer ul li,
-  .yes-no .answer ul li,
-  .choice-5-pt-radio .answer ul li {
+.yes-no .answer ul li,
+.choice-5-pt-radio .answer ul li {
   display:inline;
   padding-right:20px;
 }
@@ -1456,7 +1456,7 @@ p.problem {
 
 table.question {}
 table.question thead th,
-  table.question tbody tr.repeat th {
+table.question tbody tr.repeat th {
   padding:2px 5px;
   text-align:center;
   vertical-align:top;
@@ -1472,17 +1472,17 @@ table.question tbody td {
 }
 
 table.question tbody th.answertext,
-  .array-flexible-column tbody th.arraycaptionleft,
-  .array-flexible-row tbody th.answertextright { /* Predifined answer */
+.array-flexible-column tbody th.arraycaptionleft,
+.array-flexible-row tbody th.answertextright { /* Predifined answer */
   font-weight:400;
 }
 
 table.question tbody .array1,
-  .array-flexible-column table.question .odd  {
+.array-flexible-column table.question .odd  {
   background-color:#f0f0f0;
 }
 table.question tbody .array2,
-  .array-flexible-column table.question .even {
+.array-flexible-column table.question .even {
   background-color:#fff;
 }
 table.question tbody tr.array1:hover, table.question tbody tr.array2:hover {
@@ -1496,7 +1496,7 @@ table.question tbody td label input.radio {}
 .array-multi-flexi tbody td input {}
 
 .array-flexible-column tbody th.arraycaptionleft,
-  .array-flexible-row tbody th.answertextright {
+.array-flexible-row tbody th.answertextright {
   text-align:left;
   padding:3px;
 }
@@ -1518,7 +1518,7 @@ table.question tbody td label input.radio {}
 .array-flexible-duel-scale tbody td.ddarrayseparator {
   background-color:#fff;
   margin:0;
-  padding:0;    
+  padding:0;
 }
 
 .array-flexible-duel-scale tbody td.ddprefix {
@@ -1633,19 +1633,19 @@ table.question tbody td label input.radio {}
 }
 
 .numeric-multi .answer ul li span.input input:focus {background: #FFF;}
-    
-  .numeric-multi .answer li span.input,
-  .numeric-multi .answer li.multiplenumerichelp span {
+
+.numeric-multi .answer li span.input,
+.numeric-multi .answer li.multiplenumerichelp span {
   text-align:left;
 }
-  
-  
+
+
 .numeric-multi .answer ul li label.slider-label {
   font-size:100%;
   vertical-align:middle;
   padding:0 15px 0 0;
 }
-.numeric-multi .answer ul li div.slider_lefttext { /* text on the left side of slider bar */ 
+.numeric-multi .answer ul li div.slider_lefttext { /* text on the left side of slider bar */
   padding:0 15px 0 0;
   text-align:right;
   vertical-align:middle;
@@ -1710,7 +1710,7 @@ table.question tbody td label input.radio {}
   background: #f0f0f0;
   border: 1px solid #6f6f6f;
   margin-bottom: 3px;
-  cursor: move; 
+  cursor: move;
 }
 
 .dragDropTable .columns2 strong.SortableTitle {
@@ -1730,7 +1730,7 @@ table.question tbody td label input.radio {}
   background: #ddd;
   border: 1px solid #6f6f6f;
   margin-bottom: 3px;
-  cursor: move; 
+  cursor: move;
 }
 
 
@@ -1795,7 +1795,7 @@ table.question tbody td label input.radio {}
 /* 5 point choice question */
 .choice-5-pt-radio {}
 .choice-5-pt-radio .answer ul li input.radio {}
-.choice-5-pt-radio .answer ul li label.answertext {} 
+.choice-5-pt-radio .answer ul li label.answertext {}
 
 
 
@@ -1999,8 +1999,8 @@ ul.last {}
 .allinone .withindex{margin:0}
 
 #index {
-	clear: both;
-	width: 100%;
+  clear: both;
+  width: 100%;
   padding:20px 0 20px 30px;
   background: #f8f8f8;
   border-top: 1px solid #dfded5;
@@ -2166,12 +2166,12 @@ span.hide-tip div.error {
 
 /* II / 3b. Limesurvey 1.91 validation styles					*/
 p.good
-  {
+{
   color: green;
 }
 
 p.problem
-  {
+{
   color: red;
 }
 
@@ -2183,10 +2183,10 @@ p.problem
 
 /* START: Clearfix */
 .clearfix:after {
-  content:"."; 
-  display:block; 
-  height:0; 
-  clear:both; 
+  content:".";
+  display:block;
+  height:0;
+  clear:both;
   visibility:hidden;
 }
 .clearfix {display:inline-block;}
@@ -2194,4 +2194,27 @@ p.problem
 * html .clearfix {height:1%;}
 .clearfix {display:block;}
 /* End hide from IE-mac */
-/* END: Clearfix */                                                                                                                                              
+/* END: Clearfix */
+.mobile-date{
+  display:none;
+}
+.full-date{
+  display:block;
+}
+@media screen and (max-width:736px){
+  .b-Date{
+    background-color:#e8e8e8;
+    font-size: 0.9em;
+    margin-left: 10px;
+    padding: 6px;
+    margin-top: 10px;
+    display:inline-block;
+    text-transform: lowercase;
+  }
+  .mobile-date{
+    display:block;
+  }
+  .full-date{
+    display:none;
+  }
+}

--- a/upload/templates/ProofPilot_final/template_mobile.css
+++ b/upload/templates/ProofPilot_final/template_mobile.css
@@ -1,7 +1,7 @@
-                                                                                                                                                                                                                /*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
 /* START: CSS reset */
 html,body,div,dl,dt,dd,ul,p,blockquote,pre,th,td,
-  form,fieldset,input,textarea {
+form,fieldset,input,textarea {
   margin:0;
   padding:0;
 }
@@ -9,7 +9,7 @@ table {
   border-collapse:collapse;
   border-spacing:0;
 }
-fieldset,img,abbr,acronym { 
+fieldset,img,abbr,acronym {
   border:0;
 }
 ol,ul {
@@ -73,19 +73,19 @@ h3 {
 }
 
 a:link, a:visited {
-color: #bc3d34;
-text-decoration: underline;
+  color: #bc3d34;
+  text-decoration: underline;
 }
 a:hover, a:focus {
-text-decoration: none;
+  text-decoration: none;
 }
 
 a.upload:link, a.upload:visited {
-color: #6f6f6f;
-text-decoration: underline;
+  color: #6f6f6f;
+  text-decoration: underline;
 }
 a.upload:hover, a.upload:focus {
-text-decoration: none;
+  text-decoration: none;
 }
 
 
@@ -120,25 +120,25 @@ textarea {
 /*----------------------------------------------------------------------------*/
 /* START: Centered vertical alignment */
 #surveylist,
-  #surveyinfo, #privacynote,
-  #surveydata,
-  #register,
-  #load, #save,
-  .printouttitle, .printouttable th,
-  .groupname, .groupdescription,
-  p.captcha,
-  #tokenform ul li {
+#surveyinfo, #privacynote,
+#surveydata,
+#register,
+#load, #save,
+.printouttitle, .printouttable th,
+.groupname, .groupdescription,
+p.captcha,
+#tokenform ul li {
   text-align:center;
 }
 table.register,
-  #load table, #save table {
+#load table, #save table {
   margin:0 auto;
 }
 
 
 /* Answertext alignment (important when questions only are aligned left) */
 .numeric-multi .answer ul li label,
-  .multiple-short-txt .answer ul li label {
+.multiple-short-txt .answer ul li label {
   text-align:left;
 }
 /* END: Centered vertical alignment */
@@ -218,7 +218,7 @@ table.register,
 /*----------------------------------------------------------------------------*/
 /* Headings */
 #surveylist h1, #surveyinfo h1, #surveydata h1, .printouttitle,
-  #load h1, #save h1 {}
+#load h1, #save h1 {}
 /*----------------------------------------------------------------------------*/
 
 
@@ -228,15 +228,15 @@ table.register,
 /*----------------------------------------------------------------------------*/
 /* Buttons */
 #loadbutton, #savebutton,
-  input.submit,
-  .clearall, .saveall,
-  .date p.question button.ui-datepicker-triggert {
+input.submit,
+.clearall, .saveall,
+.date p.question button.ui-datepicker-triggert {
   padding:1px 4px;
 }
 
 #registercontinue,
-  #loadbutton, #savebutton,
-  #tokenform input.submit {
+#loadbutton, #savebutton,
+#tokenform input.submit {
   /* To use, when button bg-color is same as navigator container bg-color,
   but not page bg-color */
 }
@@ -300,20 +300,20 @@ table.register,
   margin: 0px 0px 25px 0px;
   width: 100%;
   font-weight: 700;
-  font-style: normal;	
+  font-style: normal;
 }
 
 
 #surveyinfo #content {
   color: #9a9a9a;
   font-size: 17px;
-	padding: 0 15px;
-	margin-bottom: 30px;
-	text-align: left;
+  padding: 0 15px;
+  margin-bottom: 30px;
+  text-align: left;
 }
 
 #surveyinfo #content p {
-  margin-bottom: 15px; 
+  margin-bottom: 15px;
 }
 
 .surveydescription {
@@ -323,8 +323,8 @@ table.register,
   margin:30px 0;
   color: #9a9a9a;
   font-size: 17px;
-	padding: 0 15px;
-	text-align: left;
+  padding: 0 15px;
+  text-align: left;
 }
 .therearexquestions {
   font-style:italic;
@@ -335,9 +335,9 @@ table.register,
 #privacynote {
   font-size:100%;
   color: #9a9a9a;
-	padding: 0 15px;
-	margin-bottom: 30px;
-	text-align: left;
+  padding: 0 15px;
+  margin-bottom: 30px;
+  text-align: left;
 }
 #privacynote span { /* Privacy note title */
 }
@@ -370,7 +370,7 @@ table.register,
   margin:20px 12% 0;
   background-color:#fff;
 }
-.assessmentheading {  
+.assessmentheading {
   font-weight:700;
   background-color:#ccc;
   padding:3px;
@@ -385,7 +385,7 @@ table.register,
   padding:3px;
 }
 #assessments table td {;
-    padding:3px;
+  padding:3px;
 }
 
 
@@ -405,20 +405,20 @@ table.register,
   margin: 0px 0px 25px 0px;
   width: 100%;
   font-weight: 700;
-  font-style: normal;	
+  font-style: normal;
 }
 
 
 #completed #content {
   color: #9a9a9a;
   font-size: 15px;
-	padding: 0 30px;
-	margin-bottom: 30px;
-	text-align: center;
+  padding: 0 30px;
+  margin-bottom: 30px;
+  text-align: center;
 }
 
 #completed #content p {
-  margin-bottom: 15px; 
+  margin-bottom: 15px;
 }
 
 .success {
@@ -428,7 +428,7 @@ table.register,
   font-weight: 700;
   font-size: 28px;
   text-align: center;
-  margin-bottom: 20px; 
+  margin-bottom: 20px;
 }
 
 
@@ -525,10 +525,10 @@ table.register td input.text { /* input form fields */
 /*----------------------------------------------------------------------------*/
 /* Public Statistics */
 #statsContainer { /* Container */
-	border-top: 52px solid #7ca51a;
-	overflow: auto;
-	width: 100%;
-	max-width: 800px;
+  border-top: 52px solid #7ca51a;
+  overflow: auto;
+  width: 100%;
+  max-width: 800px;
 }
 #statsContainer .statsSurveyTitle { /* Main Title */
   font-size:130%;
@@ -547,22 +547,22 @@ table.register td input.text { /* input form fields */
 
 #statsContainer .statsSurveyTitle {
   padding: 0;
-	color: #4a4a4a;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 28px;
-	text-align: center;
-	margin-bottom: 10px;
+  color: #4a4a4a;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 28px;
+  text-align: center;
+  margin-bottom: 10px;
 }
 
 .statsNumRecords {
   padding: 10px 0px 0px 0px;
   text-align: center;
-	color: #4a4a4a;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
+  color: #4a4a4a;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
 }
 
 div.fieldSummary {
@@ -589,22 +589,22 @@ table.statisticstable {
 
 
 table.statisticstable td {
-	width: 100%;
+  width: 100%;
   line-height: 190%;
   border-bottom: 1px solid #BBC6CC;
- 	text-align: center;
-	padding: 2px 20px;
+  text-align: center;
+  padding: 2px 20px;
   max-width: 760px !important;
 }
 
 table.statisticstable th {
-	text-align: center;
-	padding: 10px 0;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 15px;
-	padding: 10px 20px;
+  text-align: center;
+  padding: 10px 0;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  padding: 10px 20px;
 }
 
 
@@ -614,20 +614,20 @@ table.statisticstable img {
 }
 
 table.statisticssummary {
-	margin: 0 0 20px 20px;
+  margin: 0 0 20px 20px;
 }
 
 table.statisticssummary thead tr th {
-	font-family: 'Roboto', sans-serif;
-	color: #bc3d34;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 17px;
-	padding-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+  color: #bc3d34;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 17px;
+  padding-bottom: 10px;
 }
 
 table.statisticssummary tbody tr th {
-	padding-right: 10px;
+  padding-right: 10px;
 }
 
 
@@ -640,7 +640,7 @@ table.statisticssummary tbody tr th {
 /*----------------------------------------------------------------------------*/
 /* START: Group / Question parts */
 #group-wrapper {
-	margin: 0;
+  margin: 0;
   padding: 15px;
   width: 100%;
   -webkit-box-sizing: border-box;
@@ -719,31 +719,31 @@ div.answer {
 
 }
 .date .answer,
-  .gender .answer,
-  .numeric .answer,
-  .numeric-multi .answer,
-  .ranking .answer,
-  .yes-no .answer,
-  .language .answer,
-  .multiple-opt .answer,
-  .multiple-opt-comments .answer,
-  .list-dropdown .answer,
-  .choice-5-pt-radio .answer,
-  .list-radio .answer,
-  .list-with-comment .answer,
-  .multiple-short-txt .answer,
-  .text-short .answer,
-  .text-long .answer,
-  .text-huge .answer { /* applies to all question types but array */
+.gender .answer,
+.numeric .answer,
+.numeric-multi .answer,
+.ranking .answer,
+.yes-no .answer,
+.language .answer,
+.multiple-opt .answer,
+.multiple-opt-comments .answer,
+.list-dropdown .answer,
+.choice-5-pt-radio .answer,
+.list-radio .answer,
+.list-with-comment .answer,
+.multiple-short-txt .answer,
+.text-short .answer,
+.text-long .answer,
+.text-huge .answer { /* applies to all question types but array */
 }
 
 
 /* Main questionhelp box */
 div.questionhelp {
-	font-size: 85%;
-	line-height: 18px;
-	margin: 15px 10px 0 10px;
-	font-style: normal;
+  font-size: 85%;
+  line-height: 18px;
+  margin: 15px 10px 0 10px;
+  font-style: normal;
 }
 div.questionhelp img {
   margin:0 5px 0 0;
@@ -751,22 +751,22 @@ div.questionhelp img {
   vertical-align:middle;
 }
 .date div.questionhelp,
-  .gender  div.questionhelp,
-  .numeric  div.questionhelp,
-  .numeric-multi  div.questionhelp,
-  .ranking  div.questionhelp,
-  .yes-no  div.questionhelp,
-  .language  div.questionhelp,
-  .multiple-opt  div.questionhelp,
-  .multiple-opt-comments  div.questionhelp,
-  .list-dropdown  div.questionhelp,
-  .choice-5-pt-radio  div.questionhelp,
-  .list-radio  div.questionhelp,
-  .list-with-comment  div.questionhelp,
-  .multiple-short-txt  div.questionhelp,
-  .text-short  div.questionhelp,
-  .text-long  div.questionhelp,
-  .text-huge  div.questionhelp { /* applies to all question types but array */
+.gender  div.questionhelp,
+.numeric  div.questionhelp,
+.numeric-multi  div.questionhelp,
+.ranking  div.questionhelp,
+.yes-no  div.questionhelp,
+.language  div.questionhelp,
+.multiple-opt  div.questionhelp,
+.multiple-opt-comments  div.questionhelp,
+.list-dropdown  div.questionhelp,
+.choice-5-pt-radio  div.questionhelp,
+.list-radio  div.questionhelp,
+.list-with-comment  div.questionhelp,
+.multiple-short-txt  div.questionhelp,
+.text-short  div.questionhelp,
+.text-long  div.questionhelp,
+.text-huge  div.questionhelp { /* applies to all question types but array */
 }
 /* END: Question parts */
 /*----------------------------------------------------------------------------*/
@@ -777,16 +777,16 @@ div.questionhelp img {
 
 /* START: Navigator */
 #navigator {
-clear: both;
-margin: 0;
-padding: 0;
-background: #f8f8f8;
-border-top: 1px solid #cfcfcf;
-padding: 30px 15px 0 15px;
-margin-top: 30px;
-height: auto;
-width: auto;
-bottom: 0;
+  clear: both;
+  margin: 0;
+  padding: 0;
+  background: #f8f8f8;
+  border-top: 1px solid #cfcfcf;
+  padding: 30px 15px 0 15px;
+  margin-top: 30px;
+  height: auto;
+  width: auto;
+  bottom: 0;
 }
 #navigator #left {
   clear: both;
@@ -808,258 +808,258 @@ bottom: 0;
   margin:0 auto;
   padding:0;
   text-align: center;
-	width: auto;
-	padding: 0 15px;
-	margin-bottom: 30px;
+  width: auto;
+  padding: 0 15px;
+  margin-bottom: 30px;
 }
 
 /* Submit buttons */
 
 .submit, input.submit {
-height: 52px;
-font-size: 16px;
-line-height: 52px;
-margin: 0px;
-color: #FFFFFF !important;
-border: 1px solid #7ea61f;
-background: #97c42c;
-background: -moz-linear-gradient(top, #97c42c 0%, #7fa71f 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#97c42c), color-stop(100%,#7fa71f));
-background: -webkit-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
-background: -o-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
-background: -ms-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
-background: linear-gradient(to bottom, #97c42c 0%,#7fa71f 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#97c42c', endColorstr='#7fa71f',GradientType=0 );
+  height: 52px;
+  font-size: 16px;
+  line-height: 52px;
+  margin: 0px;
+  color: #FFFFFF !important;
+  border: 1px solid #7ea61f;
+  background: #97c42c;
+  background: -moz-linear-gradient(top, #97c42c 0%, #7fa71f 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#97c42c), color-stop(100%,#7fa71f));
+  background: -webkit-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
+  background: -o-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
+  background: -ms-linear-gradient(top, #97c42c 0%,#7fa71f 100%);
+  background: linear-gradient(to bottom, #97c42c 0%,#7fa71f 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#97c42c', endColorstr='#7fa71f',GradientType=0 );
 
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-text-transform: uppercase;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
 .submit:hover, input.submit:hover {
-border: 1px solid #608016;
-background: #6e8f20;
-background: -moz-linear-gradient(top, #6e8f20 0%, #5d7a17 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8f20), color-stop(100%,#5d7a17));
-background: -webkit-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
-background: -o-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
-background: -ms-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
-background: linear-gradient(to bottom, #6e8f20 0%,#5d7a17 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8f20', endColorstr='#5d7a17',GradientType=0 );
+  border: 1px solid #608016;
+  background: #6e8f20;
+  background: -moz-linear-gradient(top, #6e8f20 0%, #5d7a17 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8f20), color-stop(100%,#5d7a17));
+  background: -webkit-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
+  background: -o-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
+  background: -ms-linear-gradient(top, #6e8f20 0%,#5d7a17 100%);
+  background: linear-gradient(to bottom, #6e8f20 0%,#5d7a17 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8f20', endColorstr='#5d7a17',GradientType=0 );
 }
 
 /* Move next & prev buttons */
 
 #movenextbtn {
-height: 52px;
-font-size: 16px;
-line-height: 52px;
-margin: 0px;
-color: #484444 !important;
-border: 1px solid #d3d3d3;
-background: #f5f5f5;
-background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
-background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
-padding-left: 25px;
-padding-right: 25px;
-width: 49%;
-float: right;
+  height: 52px;
+  font-size: 16px;
+  line-height: 52px;
+  margin: 0px;
+  color: #484444 !important;
+  border: 1px solid #d3d3d3;
+  background: #f5f5f5;
+  background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
+  background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
+  padding-left: 25px;
+  padding-right: 25px;
+  width: 49%;
+  float: right;
 }
 
 #movenextbtn:hover {
-border-color: #b5b5b5;
-background: #c7c7c7;
-background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
-background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
+  border-color: #b5b5b5;
+  background: #c7c7c7;
+  background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
+  background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
 }
 
 .ui-button-text-icon-secondary .ui-button-text, .ui-button-text-icons .ui-button-text {
-background: url(icon_next.png) no-repeat  100% 50%;
-background-size: 9px 13px;
-padding: 0;
-padding-right: 25px;
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 16px;
-text-transform: uppercase;
+  background: url(icon_next.png) no-repeat  100% 50%;
+  background-size: 9px 13px;
+  padding: 0;
+  padding-right: 25px;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  text-transform: uppercase;
 }
 
 .ui-state-default .ui-icon {
-	background: none;
-	display: none;
+  background: none;
+  display: none;
 }
 
 #moveprevbtn {
-height: 52px;
-font-size: 16px;
-line-height: 52px;
-margin: 0px;
-color: #484444 !important;
-border: 1px solid #d3d3d3;
-background: #f5f5f5;
-background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
-background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
-padding-left: 25px;
-padding-right: 25px;
-width: 49%;
-float: left;
+  height: 52px;
+  font-size: 16px;
+  line-height: 52px;
+  margin: 0px;
+  color: #484444 !important;
+  border: 1px solid #d3d3d3;
+  background: #f5f5f5;
+  background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
+  background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
+  padding-left: 25px;
+  padding-right: 25px;
+  width: 49%;
+  float: left;
 }
 
 #moveprevbtn:hover {
-border-color: #b5b5b5;
-background: #c7c7c7;
-background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
-background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
+  border-color: #b5b5b5;
+  background: #c7c7c7;
+  background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
+  background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
 }
 
 .ui-button-text-icon-primary .ui-button-text, .ui-button-text-icons .ui-button-text {
-background: url(icon_back.png) no-repeat  0% 50%;
-background-size: 9px 13px;
-padding: 0;
-padding-left: 25px;
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 16px;
-text-transform: uppercase;	
+  background: url(icon_back.png) no-repeat  0% 50%;
+  background-size: 9px 13px;
+  padding: 0;
+  padding-left: 25px;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  text-transform: uppercase;
 }
 
 /* Save All button */
 .saveall {
-height: 52px;
-font-size: 16px;
-margin: 0px;
-margin-bottom: 15px;
-color: #FFF !important;
-border: 1px solid #64adc9;
-background: #9ec5d3;
-background: -moz-linear-gradient(top, #9ec5d3 0%, #769ead 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#9ec5d3), color-stop(100%,#769ead));
-background: -webkit-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
-background: -o-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
-background: -ms-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
-background: linear-gradient(to bottom, #9ec5d3 0%,#769ead 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#9ec5d3', endColorstr='#769ead',GradientType=0 );
+  height: 52px;
+  font-size: 16px;
+  margin: 0px;
+  margin-bottom: 15px;
+  color: #FFF !important;
+  border: 1px solid #64adc9;
+  background: #9ec5d3;
+  background: -moz-linear-gradient(top, #9ec5d3 0%, #769ead 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#9ec5d3), color-stop(100%,#769ead));
+  background: -webkit-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
+  background: -o-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
+  background: -ms-linear-gradient(top, #9ec5d3 0%,#769ead 100%);
+  background: linear-gradient(to bottom, #9ec5d3 0%,#769ead 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#9ec5d3', endColorstr='#769ead',GradientType=0 );
 
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;
-width: 100%;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
+  width: 100%;
 }
 
 .saveall:hover {
-border-color: #558ca2;
-background: #6e8993;
-background: -moz-linear-gradient(top, #6e8993 0%, #526e79 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8993), color-stop(100%,#526e79));
-background: -webkit-linear-gradient(top, #6e8993 0%,#526e79 100%);
-background: -o-linear-gradient(top, #6e8993 0%,#526e79 100%);
-background: -ms-linear-gradient(top, #6e8993 0%,#526e79 100%);
-background: linear-gradient(to bottom, #6e8993 0%,#526e79 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8993', endColorstr='#526e79',GradientType=0 );
+  border-color: #558ca2;
+  background: #6e8993;
+  background: -moz-linear-gradient(top, #6e8993 0%, #526e79 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6e8993), color-stop(100%,#526e79));
+  background: -webkit-linear-gradient(top, #6e8993 0%,#526e79 100%);
+  background: -o-linear-gradient(top, #6e8993 0%,#526e79 100%);
+  background: -ms-linear-gradient(top, #6e8993 0%,#526e79 100%);
+  background: linear-gradient(to bottom, #6e8993 0%,#526e79 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6e8993', endColorstr='#526e79',GradientType=0 );
 }
 
 /* Clear All button */
 .clearall {
-height: 52px;
-font-size: 16px;
-margin: 0px;
-margin-bottom: 30px;
-color: #FFF !important;
-border: 1px solid #6e6e6e;
-background: #7c7e7d;
-background: -moz-linear-gradient(top, #7c7e7d 0%, #5c5d5f 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#7c7e7d), color-stop(100%,#5c5d5f));
-background: -webkit-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
-background: -o-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
-background: -ms-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
-background: linear-gradient(to bottom, #7c7e7d 0%,#5c5d5f 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#7c7e7d', endColorstr='#5c5d5f',GradientType=0 );
+  height: 52px;
+  font-size: 16px;
+  margin: 0px;
+  margin-bottom: 30px;
+  color: #FFF !important;
+  border: 1px solid #6e6e6e;
+  background: #7c7e7d;
+  background: -moz-linear-gradient(top, #7c7e7d 0%, #5c5d5f 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#7c7e7d), color-stop(100%,#5c5d5f));
+  background: -webkit-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
+  background: -o-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
+  background: -ms-linear-gradient(top, #7c7e7d 0%,#5c5d5f 100%);
+  background: linear-gradient(to bottom, #7c7e7d 0%,#5c5d5f 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#7c7e7d', endColorstr='#5c5d5f',GradientType=0 );
 
-display: inline-block;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 700;
-font-size: 15px;
-text-transform: uppercase;
-width: 100%;
+  display: inline-block;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 15px;
+  text-transform: uppercase;
+  width: 100%;
 }
 
 .clearall:hover {
-border-color: #6e6e6e;
-background: #5e605f;
-background: -moz-linear-gradient(top, #5e605f 0%, #464748 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#5e605f), color-stop(100%,#464748));
-background: -webkit-linear-gradient(top, #5e605f 0%,#464748 100%);
-background: -o-linear-gradient(top, #5e605f 0%,#464748 100%);
-background: -ms-linear-gradient(top, #5e605f 0%,#464748 100%);
-background: linear-gradient(to bottom, #5e605f 0%,#464748 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5e605f', endColorstr='#464748',GradientType=0 );
+  border-color: #6e6e6e;
+  background: #5e605f;
+  background: -moz-linear-gradient(top, #5e605f 0%, #464748 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#5e605f), color-stop(100%,#464748));
+  background: -webkit-linear-gradient(top, #5e605f 0%,#464748 100%);
+  background: -o-linear-gradient(top, #5e605f 0%,#464748 100%);
+  background: -ms-linear-gradient(top, #5e605f 0%,#464748 100%);
+  background: linear-gradient(to bottom, #5e605f 0%,#464748 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5e605f', endColorstr='#464748',GradientType=0 );
 }
 
 /* Export-Button */
 
 #exportbutton {
-height: 52px;
-font-size: 16px;
-font-weight: 700;
-line-height: 52px;
-margin: 0px;
-color: #484444 !important;
-border: 1px solid #d3d3d3;
-background: #f5f5f5;
-background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
-background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
-background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
-background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
-padding-left: 25px;
-padding-right: 25px;
-width: 49%;
-margin: 20px 0;
+  height: 52px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 52px;
+  margin: 0px;
+  color: #484444 !important;
+  border: 1px solid #d3d3d3;
+  background: #f5f5f5;
+  background: -moz-linear-gradient(top, #f5f5f5 0%, #e1e1e1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e1e1e1));
+  background: -webkit-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -o-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: -ms-linear-gradient(top, #f5f5f5 0%,#e1e1e1 100%);
+  background: linear-gradient(to bottom, #f5f5f5 0%,#e1e1e1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e1e1e1',GradientType=0 );
+  padding-left: 25px;
+  padding-right: 25px;
+  width: 49%;
+  margin: 20px 0;
 }
 
 #exportbutton:hover {
-	cursor: pointer;
-	border-color: #b5b5b5;
-	background: #c7c7c7;
-	background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
-	background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-	background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-	background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
-	background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
+  cursor: pointer;
+  border-color: #b5b5b5;
+  background: #c7c7c7;
+  background: -moz-linear-gradient(top, #c7c7c7 0%, #b7b7b7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c7c7c7), color-stop(100%,#b7b7b7));
+  background: -webkit-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -o-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 0%,#b7b7b7 100%);
+  background: linear-gradient(to bottom, #c7c7c7 0%,#b7b7b7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c7c7c7', endColorstr='#b7b7b7',GradientType=0 );
 }
 
 /* END: Navigator */
@@ -1079,7 +1079,7 @@ margin: 20px 0;
   width: 100%;
 }
 #progress-wrapper {
-	clear: both;
+  clear: both;
   height:16px;
   margin: 0;
   margin-left: auto;
@@ -1114,9 +1114,9 @@ margin: 20px 0;
   background-image: none;
   border: 1px solid #666;
   border-radius: 8px;
-  
+
   background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#FFFFFF), to(#edf3f4));
-  background: -webkit-linear-gradient(top, #FFFFFF, #edf3f4); 
+  background: -webkit-linear-gradient(top, #FFFFFF, #edf3f4);
   background: -moz-linear-gradient(top, #FFFFFF, #edf3f4);
   background: -ms-linear-gradient(top, #FFFFFF, #edf3f4);
   background: -o-linear-gradient(top, #FFFFFF, #edf3f4);
@@ -1141,13 +1141,13 @@ select.languagechanger {}
 
 .printouttitle { /* see h1 */
   display:block;
-	color: #4a4a4a;
-	font-family: 'Roboto', sans-serif;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 28px;
-	text-align: center;
-	margin-bottom: 10px;
+  color: #4a4a4a;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 28px;
+  text-align: center;
+  margin-bottom: 10px;
 }
 
 .printouttable {}
@@ -1165,35 +1165,35 @@ select.languagechanger {}
 }
 
 tr.printanswersgroup {
-	font-family: 'Roboto', sans-serif;
-	color: #bc3d34;
-	font-style: normal;
-	font-weight: 700;
-	font-size: 17px;
-	text-align: center;
+  font-family: 'Roboto', sans-serif;
+  color: #bc3d34;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 17px;
+  text-align: center;
 }
 
 tr.printanswersgroup td {
-		padding: 30px 0 10px 0;
-		border: 0;
+  padding: 30px 0 10px 0;
+  border: 0;
 }
 
 tr.printanswersquestionhead {
-	font-family: 'Roboto', sans-serif;
-	color: #4a4a4a;
-	font-style: normal;
-	font-weight: 700;
-	margin-bottom: 20px;
-	text-align: center;
+  font-family: 'Roboto', sans-serif;
+  color: #4a4a4a;
+  font-style: normal;
+  font-weight: 700;
+  margin-bottom: 20px;
+  text-align: center;
 }
 
 tr.printanswersquestionhead td {
-	border: 0;
-	padding: 15px 0 2px 0;
+  border: 0;
+  padding: 15px 0 2px 0;
 }
 
 tr.printanswersquestion td {
-	border-left: 0;
+  border-left: 0;
 }
 
 
@@ -1232,7 +1232,7 @@ p#tokenmessage {
 #tokenform ul li input#token {}
 #tokenform ul li img#captchaimage {}
 #token,
-  #captchaimage {
+#captchaimage {
   margin:3px 5px;
 }
 #tokenform ul li input.submit {}
@@ -1257,26 +1257,26 @@ span.asterisk { /* Asterisk when question mandatory */
 
 /* ul in table style */
 .numeric-multi .answer ul,
-  .multiple-opt-comments .answer ul,
-  .multiple-short-txt .answer ul {
+.multiple-opt-comments .answer ul,
+.multiple-short-txt .answer ul {
   display:table;
 }
 .numeric-multi .answer ul li,
-  .multiple-opt-comments .answer ul li,
-  .multiple-short-txt .answer ul li {
+.multiple-opt-comments .answer ul li,
+.multiple-short-txt .answer ul li {
   display:table-row;
 }
 .numeric-multi .answer ul li label,
-  .numeric-multi .answer ul li span.input,
-  .numeric-multi .answer ul li.multiplenumerichelp span,
-  .numeric-multi .answer ul li div.slider_lefttext,
-  .numeric-multi .answer ul li label.slider-label,
-  .numeric-multi .answer ul li div.multinum-slider,
-  .numeric-multi .answer ul li div.slider_righttext,
-  .multiple-opt-comments .answer ul li span.option,
-  .multiple-opt-comments .answer ul li span.comment,
-  .multiple-short-txt .answer ul li label,
-  .multiple-short-txt .answer ul li span {
+.numeric-multi .answer ul li span.input,
+.numeric-multi .answer ul li.multiplenumerichelp span,
+.numeric-multi .answer ul li div.slider_lefttext,
+.numeric-multi .answer ul li label.slider-label,
+.numeric-multi .answer ul li div.multinum-slider,
+.numeric-multi .answer ul li div.slider_righttext,
+.multiple-opt-comments .answer ul li span.option,
+.multiple-opt-comments .answer ul li span.comment,
+.multiple-short-txt .answer ul li label,
+.multiple-short-txt .answer ul li span {
   display:table-cell;
   vertical-align:middle;
 }
@@ -1289,99 +1289,99 @@ span.asterisk { /* Asterisk when question mandatory */
 /* end correction */
 
 .numeric-multi .answer ul li label,
-  .multiple-opt-comments .answer ul li span.option,
-  .multiple-short-txt .answer ul li label {
+.multiple-opt-comments .answer ul li span.option,
+.multiple-short-txt .answer ul li label {
   padding:3px 10px 3px 0;
 }
 .numeric-multi .answer ul li span.input,
-  .numeric-multi .answer ul li.multiplenumerichelp span,
-  .multiple-opt-comments .answer ul li span.comment,
-  .multiple-short-txt .answer ul li span { /* compare with padding of table answertext */
+.numeric-multi .answer ul li.multiplenumerichelp span,
+.multiple-opt-comments .answer ul li span.comment,
+.multiple-short-txt .answer ul li span { /* compare with padding of table answertext */
   padding:3px;
 }
 
 /* All input form fields (careful with background-color !) */
 input.text,
-  .array-multi-flexi-text tbody td label input,
-  .array-multi-flexi tbody td input,
-  .date p.question input,
-  .numeric-multi li.multiplenumerichelp input.good,
-  .numeric-multi li.multiplenumerichelp input.problem,
-  .numeric-multi .answer ul li span.input input {
-height: 29px;
-width: auto;
-padding: 0 5px;
-font-family: 'Roboto', sans-serif;
-font-style: normal;
-font-weight: 400;
-color: #6f6f6f;
-line-height: 29px;
-background: white;
-border: 1px solid #c9c9c9;
-border-radius: 3px;
-text-align: left;
-font-size: 15px;
+.array-multi-flexi-text tbody td label input,
+.array-multi-flexi tbody td input,
+.date p.question input,
+.numeric-multi li.multiplenumerichelp input.good,
+.numeric-multi li.multiplenumerichelp input.problem,
+.numeric-multi .answer ul li span.input input {
+  height: 29px;
+  width: auto;
+  padding: 0 5px;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  color: #6f6f6f;
+  line-height: 29px;
+  background: white;
+  border: 1px solid #c9c9c9;
+  border-radius: 3px;
+  text-align: left;
+  font-size: 15px;
 }
 
 
 p.question.answer-item.text-item.inputwidth-15.withprefix.withsuffix input.text {
-	margin: 0 5px;
-	width: 100px;
+  margin: 0 5px;
+  width: 100px;
 }
 
 p.question.question.answer-item.text-item.numeric-item.withprefix input.text {
-	margin: 0 10px;
-	width: 100px;
+  margin: 0 10px;
+  width: 100px;
 }
 
 
 
 /* Hovereffect in text form fields and areas */
 input.text:focus,
-  .array-multi-flexi-text tbody td label input:focus,
-  .array-multi-flexi tbody td input:focus,
-  .date p.question input:focus,
-  .numeric-multi .answer ul li span.input input:focus,
-  .textarea:focus {
+.array-multi-flexi-text tbody td label input:focus,
+.array-multi-flexi tbody td input:focus,
+.date p.question input:focus,
+.numeric-multi .answer ul li span.input input:focus,
+.textarea:focus {
   background-color:#FFF;
 }
 
 
 /* Right align of text in numeric question types*/
 .numeric p.question input.text,
-  .numeric-multi li.multiplenumerichelp input,
-  .numeric-multi .answer ul li span.input input {
+.numeric-multi li.multiplenumerichelp input,
+.numeric-multi .answer ul li span.input input {
   text-align:right;
 }
 
 
 /* Alignment of checkbox/radio and text following it */
 .gender .answer ul li,
-  .yes-no .answer ul li,
-  .multiple-opt .answer ul li,
-  .choice-5-pt-radio .answer ul li,
-  .list-radio .answer ul li,
-  .list-with-comment .answer .list ul li  {
+.yes-no .answer ul li,
+.multiple-opt .answer ul li,
+.choice-5-pt-radio .answer ul li,
+.list-radio .answer ul li,
+.list-with-comment .answer .list ul li  {
   position:relative;
   margin-bottom:15px;
   text-align:left;
 }
 .gender .answer ul li input.radio,
-  .yes-no .answer ul li input.radio,
-  .multiple-opt .answer ul li input.checkbox,
-  .choice-5-pt-radio .answer ul li input.radio,
-  .list-radio .answer ul li input.radio,
-  .list-with-comment .answer .list ul li input.radio {
+.yes-no .answer ul li input.radio,
+.multiple-opt .answer ul li input.checkbox,
+.choice-5-pt-radio .answer ul li input.radio,
+.list-radio .answer ul li input.radio,
+.list-with-comment .answer .list ul li input.radio {
   position:absolute;
   top:3px;
   left:0;
 }
 .gender .answer ul li label.answertext,
-  .yes-no .answer ul li label.answertext,
-  .multiple-opt .answer ul li label.answertext,
-  .choice-5-pt-radio .answer ul li label.answertext,
-  .list-radio .answer ul li label.answertext,
-  .list-with-comment .answer .list ul li label.answertext {
+.yes-no .answer ul li label.answertext,
+.multiple-opt .answer ul li label.answertext,
+.choice-5-pt-radio .answer ul li label.answertext,
+.list-radio .answer ul li label.answertext,
+.list-with-comment .answer .list ul li label.answertext {
   display:inline-block;
   margin-left:20px;
   line-height: 20px;
@@ -1400,8 +1400,8 @@ input.text:focus,
 
 
 .gender .answer ul li,
-  .yes-no .answer ul li,
-  .choice-5-pt-radio .answer ul li {
+.yes-no .answer ul li,
+.choice-5-pt-radio .answer ul li {
   display:inline;
   padding-right:20px;
   line-height: 40px;
@@ -1440,7 +1440,7 @@ p.problem {
 
 table.question {}
 table.question thead th,
-  table.question tbody tr.repeat th {
+table.question tbody tr.repeat th {
   padding:2px 5px;
   text-align:center;
   vertical-align:bottom;
@@ -1456,17 +1456,17 @@ table.question tbody td {
 }
 
 table.question tbody th.answertext,
-  .array-flexible-column tbody th.arraycaptionleft,
-  .array-flexible-row tbody th.answertextright { /* Predifined answer */
+.array-flexible-column tbody th.arraycaptionleft,
+.array-flexible-row tbody th.answertextright { /* Predifined answer */
   font-weight:400;
 }
 
 table.question tbody .array1,
-  .array-flexible-column table.question .odd  {
+.array-flexible-column table.question .odd  {
   background-color:#f0f0f0;
 }
 table.question tbody .array2,
-  .array-flexible-column table.question .even {
+.array-flexible-column table.question .even {
   background-color:#fff;
 }
 table.question tbody tr.array1:hover, table.question tbody tr.array2:hover {
@@ -1480,7 +1480,7 @@ table.question tbody td label input.radio {}
 .array-multi-flexi tbody td input {}
 
 .array-flexible-column tbody th.arraycaptionleft,
-  .array-flexible-row tbody th.answertextright {
+.array-flexible-row tbody th.answertextright {
   text-align:left;
   padding:3px;
 }
@@ -1502,7 +1502,7 @@ table.question tbody td label input.radio {}
 .array-flexible-duel-scale tbody td.ddarrayseparator {
   background-color:#fff;
   margin:0;
-  padding:0;    
+  padding:0;
 }
 
 .array-flexible-duel-scale tbody td.ddprefix {
@@ -1589,21 +1589,21 @@ table.question tbody td label input.radio {}
 .numeric-multi .answer ul li.multiplenumerichelp {/* Total resp. Remaining hints */
 }
 .numeric-multi .answer ul li.multiplenumerichelp span.label {
-display: inline-block;
-float: left;
-padding-left: 0;
+  display: inline-block;
+  float: left;
+  padding-left: 0;
 }
 
 .numeric-multi .answer ul li.multiplenumerichelp span.dynamic_remaining {
-text-align: left;
-float: left;
-padding-left: 0;
+  text-align: left;
+  float: left;
+  padding-left: 0;
 }
 
 .numeric-multi .answer ul li.multiplenumerichelp span.dynamic_sum {
-text-align: left;
-float: left;
-padding-left: 0;	
+  text-align: left;
+  float: left;
+  padding-left: 0;
 }
 
 
@@ -1635,66 +1635,66 @@ padding-left: 0;
 }
 
 .numeric-multi .answer ul li span.input input:focus {background: #FFF;}
-    
-    .numeric-multi .answer li span.input,
-    .numeric-multi .answer li.multiplenumerichelp span {
-    text-align:left;
-  }
-  
-  
-  .numeric-multi .answer ul li label.slider-label {
-  	clear: both;
-    font-size:100%;
-    vertical-align:middle;
-    padding:0 15px 0 0;
-    display: block;
-    width: 100%;
-  }
-  .numeric-multi .answer ul li div.slider_lefttext { /* text on the left side of slider bar */
-  	padding: 0;
-    padding:0 15px 0 0;
-    text-align:right;
-    vertical-align:middle;
-    font-size:90%;
-  }
-  .numeric-multi .answer ul li div.slider_righttext { /* text on the right side of slider bar */
-    padding:0 0 0 15px;
-    text-align:left;
-    vertical-align:middle;
-    font-size:90%;
-  }
-  .numeric-multi .answer ul li div.multinum-slider { /* slider container */
-    vertical-align:middle;
-  }
-  
-  .numeric-multi .answer ul li.withslider {
-  	display: block;
-  	margin-bottom: 25px;
-  }
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Ranking question */
-  .ranking {}
-  .ranking table.rank {}
-  .ranking table td.label { /* Choices */
-  }
-  .ranking table td.label strong label { /* Heading for choices */
-  }
-  .ranking table td.label select.select {
-    margin-top:5px;
-  }
-  .ranking table td.output { /* Output (ranking) */
-  }
-  .ranking table td.output table {}
-  .ranking table td.output table td {
-    padding:2px 3px;
-  }
-  .ranking table td.output table td strong{ /* Heading for output */
-  }
-  .ranking table td.output table td.position {}
-  .ranking table td.output table td.item input.text {}
+
+.numeric-multi .answer li span.input,
+.numeric-multi .answer li.multiplenumerichelp span {
+  text-align:left;
+}
+
+
+.numeric-multi .answer ul li label.slider-label {
+  clear: both;
+  font-size:100%;
+  vertical-align:middle;
+  padding:0 15px 0 0;
+  display: block;
+  width: 100%;
+}
+.numeric-multi .answer ul li div.slider_lefttext { /* text on the left side of slider bar */
+  padding: 0;
+  padding:0 15px 0 0;
+  text-align:right;
+  vertical-align:middle;
+  font-size:90%;
+}
+.numeric-multi .answer ul li div.slider_righttext { /* text on the right side of slider bar */
+  padding:0 0 0 15px;
+  text-align:left;
+  vertical-align:middle;
+  font-size:90%;
+}
+.numeric-multi .answer ul li div.multinum-slider { /* slider container */
+  vertical-align:middle;
+}
+
+.numeric-multi .answer ul li.withslider {
+  display: block;
+  margin-bottom: 25px;
+}
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Ranking question */
+.ranking {}
+.ranking table.rank {}
+.ranking table td.label { /* Choices */
+}
+.ranking table td.label strong label { /* Heading for choices */
+}
+.ranking table td.label select.select {
+  margin-top:5px;
+}
+.ranking table td.output { /* Output (ranking) */
+}
+.ranking table td.output table {}
+.ranking table td.output table td {
+  padding:2px 3px;
+}
+.ranking table td.output table td strong{ /* Heading for output */
+}
+.ranking table td.output table td.position {}
+.ranking table td.output table td.item input.text {}
 
 
 .dragDropTable .columns2 {
@@ -1718,7 +1718,7 @@ padding-left: 0;
   background: #f0f0f0;
   border: 1px solid #6f6f6f;
   margin-bottom: 3px;
-  cursor: move; 
+  cursor: move;
 }
 
 .dragDropTable .columns2 strong.SortableTitle {
@@ -1740,319 +1740,319 @@ padding-left: 0;
   cursor: move;
   color: #FFF;
 }
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Boilerplate question */
-  .boilerplate  {}
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Yes-No question */
-  .yes-no {}
-  .yes-no .answer ul li input.radio {}
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Multiple Options question */
-  .multiple-opt {}
-  .multiple-opt .answer ul li {}
-  .multiple-opt .answer ul li input.checkbox {}
-  .multiple-opt .answer ul li label.answertext{}
-  .multiple-opt .answer ul li input.text { /* Comment field */
-  }
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Multiple Options question with comments */
-  .multiple-opt-comments {}
-  .multiple-opt-comments .answer ul li {display: list-item;}
-  .multiple-opt-comments .answer ul li.other {}
-  .multiple-opt-comments .answer ul li span.option label.answertext input.checkbox {}
-  .multiple-opt-comments .answer ul li span.option label.answertext input.text.other {}
-  .multiple-opt-comments .answer ul li span.option {display: block;}
-  .multiple-opt-comments .answer ul li span.comment label.answer-comment input.text {}
-  .multiple-opt-comments .answer ul li span.comment {padding: 0; margin: 5px 0 20px 0; display: block;}
-  .multiple-opt-comments .answer ul li span.comment input.text  {width: 100%; margin: 0; padding: 0; display: block;}
-  
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* List Dropdown question */
-  .list-dropdown {}
-  .list-dropdown p.question select {width: 100%;}
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* 5 point choice question */
-  .choice-5-pt-radio {}
-  .choice-5-pt-radio .answer ul li input.radio {}
-  .choice-5-pt-radio .answer ul li label.answertext {} 
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* List Radio qeustion */
-  .list-radio .answer ul li {margin-bottom: 15px;}
-  .list-radio .answer ul li input.radio {}
-  .list-radio .answer ul li label.answertext {}
-  .list-radio .answer ul li.other label input.text {
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-    display: block;
-  	margin-top: 10px;
-  }
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* List with Comment question */
-  .list-with-comment {}
-  .list-with-comment div.list ul li input.radio {}
-  .list-with-comment div.list ul li label.answertext {}
-  .list-with-comment p.comment {
-    margin-top:5px;
-  }
-  .list-with-comment p.comment label {
-    vertical-align:top;
-    display:block;
-  }
-  .list-with-comment p.comment textarea.textarea {
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-    display: block;
-  }
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Multiple Short Text question */
-  .multiple-short-txt {}
-  .multiple-short-txt .answer ul li label {}
-  .multiple-short-txt .answer ul li span input.text {
 
-  }
-  .multiple-short-txt .answer ul li span textarea.textarea {
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-  	display: block;
-    /* when entering rows in LimeSurvey settings textarea instead of input field appears */
-  }
-  .multiple-short-txt .answer li span {
-    text-align:left;
-  }
-  
-  ul.subquestions-list, ul.questions-list, ul.text-list {
 
-  }
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Short Free Text question */
-  .text-short {}
-  .text-short p.question input.text {
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-  	}
-  .text-short .answer textarea.textarea {
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-    display: block;
-  	}  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Multiple Long Text question */
-  .text-long {}
-  .text-long .answer textarea.textarea {	
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-    display: block;  	
-  }
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Huge Free Text question */
-  .text-huge {}
-  .text-huge .answer textarea.textarea {
-  	width: 100%;
-  	margin: 0;
-  	padding: 0;
-    display: block;
-  	} 
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* General question style to overwrite the ones above */
-  
-  
-  /* START: Column alignment */
-  /* Applies for: .list-radio, .multiple-opt, (.gender????), */
-  ul.cols-2-ul, ul.cols-3-ul, ul.cols-4-ul, ul.cols-5-ul, ul.cols-6-ul, ul.cols-7-ul, ul.cols-8-ul {
-    display:inline-block;
-    vertical-align:top;
-    margin-left:0;
-    margin-right:0;
-    padding-left:0;
-    padding-right:0;
-  }
-  ul.cols-2-ul {
-    width:49%;
-  }
-  ul.cols-3-ul {
-    width:32%;
-  }
-  ul.cols-4-ul {
-    width:24%;
-  }
-  ul.cols-5-ul {
-    width:19%;
-  }
-  ul.cols-6-ul {
-    width:16%;
-  }
-  ul.cols-7-ul {
-    width:14%;
-  }
-  ul.cols-8-ul {
-    width:12%;
-  }
-  ul.cols-2-ul li, ul.cols-3-ul li, ul.cols-4-ul li, ul.cols-5-ul li, ul.cols-6-ul li, ul.cols-7-ul li, ul.cols-8-ul li {
-    padding-right:5px;
-  }
-  
-  ul.first {}
-  ul.last {}
-  /* END: Column alignment */
-  
-  /*----------------------------------------------------------------------------*/
-  /* END: Question styles */
-  /*----------------------------------------------------------------------------*/
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* Jquery CSS */
-  
-  /** UI Base **/
-  .ui-wrapper {
-    border:1px solid #50A029;
-  }
-  .ui-wrapper input,.ui-wrapper textarea {
-    border:0;
-  }
-  
-  
-  /* UI Slider */
-  .ui-slider {
-    width: auto;/* slider-bar width */
-    height:9px; /* slider-bar height */
-    margin:25px 0 8px; /* required to the the callout */
-  }
-  .ui-slider .ui-slider-handle {
-    position:absolute;
-    height:23px;
-    width:12px;
-    top:-8px;
-    left:0;
-    background-image:url(slider-handle.gif);
-  }
-  .ui-state-default, .ui-widget-content .ui-state-default {
-    /* removes background-color and border behind the slider handle */
-    border:none;
-    background-color:transparent;
-  }
-  .ui-widget-content {
-    /* border-color or background-color of slider bar */
-  }
-  
-  .slider_callout {
-    height:20px;
-    width:100px;
-    overflow:hidden;
-    position:absolute;
-    top:-25px;
-    margin-left:-8px;
-    font-size:85%;
-    font-weight:400;
-    text-align:left;
-    color: #bc3d34;
-  }
-  .slider_showmin {
-    float:left;
-    width:50px;
-    margin:15px 0 0 0;
-    font-family: 'Roboto', sans-serif;
-    font-size:80%;
-    font-weight:400;
-    text-align:left;
-  }
-  .slider_showmax {
-    float: right;
-    width:80px;
-    margin:15px 0 0 0;
-    font-family: 'Roboto', sans-serif;
-    font-size:80%;
-    font-weight:400;
-    text-align:right;
-  }
-  /*----------------------------------------------------------------------------*/
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
+
+
+/*----------------------------------------------------------------------------*/
+/* Boilerplate question */
+.boilerplate  {}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Yes-No question */
+.yes-no {}
+.yes-no .answer ul li input.radio {}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Multiple Options question */
+.multiple-opt {}
+.multiple-opt .answer ul li {}
+.multiple-opt .answer ul li input.checkbox {}
+.multiple-opt .answer ul li label.answertext{}
+.multiple-opt .answer ul li input.text { /* Comment field */
+}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Multiple Options question with comments */
+.multiple-opt-comments {}
+.multiple-opt-comments .answer ul li {display: list-item;}
+.multiple-opt-comments .answer ul li.other {}
+.multiple-opt-comments .answer ul li span.option label.answertext input.checkbox {}
+.multiple-opt-comments .answer ul li span.option label.answertext input.text.other {}
+.multiple-opt-comments .answer ul li span.option {display: block;}
+.multiple-opt-comments .answer ul li span.comment label.answer-comment input.text {}
+.multiple-opt-comments .answer ul li span.comment {padding: 0; margin: 5px 0 20px 0; display: block;}
+.multiple-opt-comments .answer ul li span.comment input.text  {width: 100%; margin: 0; padding: 0; display: block;}
+
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* List Dropdown question */
+.list-dropdown {}
+.list-dropdown p.question select {width: 100%;}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* 5 point choice question */
+.choice-5-pt-radio {}
+.choice-5-pt-radio .answer ul li input.radio {}
+.choice-5-pt-radio .answer ul li label.answertext {}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* List Radio qeustion */
+.list-radio .answer ul li {margin-bottom: 15px;}
+.list-radio .answer ul li input.radio {}
+.list-radio .answer ul li label.answertext {}
+.list-radio .answer ul li.other label input.text {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+  margin-top: 10px;
+}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* List with Comment question */
+.list-with-comment {}
+.list-with-comment div.list ul li input.radio {}
+.list-with-comment div.list ul li label.answertext {}
+.list-with-comment p.comment {
+  margin-top:5px;
+}
+.list-with-comment p.comment label {
+  vertical-align:top;
+  display:block;
+}
+.list-with-comment p.comment textarea.textarea {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Multiple Short Text question */
+.multiple-short-txt {}
+.multiple-short-txt .answer ul li label {}
+.multiple-short-txt .answer ul li span input.text {
+
+}
+.multiple-short-txt .answer ul li span textarea.textarea {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+  /* when entering rows in LimeSurvey settings textarea instead of input field appears */
+}
+.multiple-short-txt .answer li span {
+  text-align:left;
+}
+
+ul.subquestions-list, ul.questions-list, ul.text-list {
+
+}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Short Free Text question */
+.text-short {}
+.text-short p.question input.text {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+.text-short .answer textarea.textarea {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Multiple Long Text question */
+.text-long {}
+.text-long .answer textarea.textarea {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Huge Free Text question */
+.text-huge {}
+.text-huge .answer textarea.textarea {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* General question style to overwrite the ones above */
+
+
+/* START: Column alignment */
+/* Applies for: .list-radio, .multiple-opt, (.gender????), */
+ul.cols-2-ul, ul.cols-3-ul, ul.cols-4-ul, ul.cols-5-ul, ul.cols-6-ul, ul.cols-7-ul, ul.cols-8-ul {
+  display:inline-block;
+  vertical-align:top;
+  margin-left:0;
+  margin-right:0;
+  padding-left:0;
+  padding-right:0;
+}
+ul.cols-2-ul {
+  width:49%;
+}
+ul.cols-3-ul {
+  width:32%;
+}
+ul.cols-4-ul {
+  width:24%;
+}
+ul.cols-5-ul {
+  width:19%;
+}
+ul.cols-6-ul {
+  width:16%;
+}
+ul.cols-7-ul {
+  width:14%;
+}
+ul.cols-8-ul {
+  width:12%;
+}
+ul.cols-2-ul li, ul.cols-3-ul li, ul.cols-4-ul li, ul.cols-5-ul li, ul.cols-6-ul li, ul.cols-7-ul li, ul.cols-8-ul li {
+  padding-right:5px;
+}
+
+ul.first {}
+ul.last {}
+/* END: Column alignment */
+
+/*----------------------------------------------------------------------------*/
+/* END: Question styles */
+/*----------------------------------------------------------------------------*/
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* Jquery CSS */
+
+/** UI Base **/
+.ui-wrapper {
+  border:1px solid #50A029;
+}
+.ui-wrapper input,.ui-wrapper textarea {
+  border:0;
+}
+
+
+/* UI Slider */
+.ui-slider {
+  width: auto;/* slider-bar width */
+  height:9px; /* slider-bar height */
+  margin:25px 0 8px; /* required to the the callout */
+}
+.ui-slider .ui-slider-handle {
+  position:absolute;
+  height:23px;
+  width:12px;
+  top:-8px;
+  left:0;
+  background-image:url(slider-handle.gif);
+}
+.ui-state-default, .ui-widget-content .ui-state-default {
+  /* removes background-color and border behind the slider handle */
+  border:none;
+  background-color:transparent;
+}
+.ui-widget-content {
+  /* border-color or background-color of slider bar */
+}
+
+.slider_callout {
+  height:20px;
+  width:100px;
+  overflow:hidden;
+  position:absolute;
+  top:-25px;
+  margin-left:-8px;
+  font-size:85%;
+  font-weight:400;
+  text-align:left;
+  color: #bc3d34;
+}
+.slider_showmin {
+  float:left;
+  width:50px;
+  margin:15px 0 0 0;
+  font-family: 'Roboto', sans-serif;
+  font-size:80%;
+  font-weight:400;
+  text-align:left;
+}
+.slider_showmax {
+  float: right;
+  width:80px;
+  margin:15px 0 0 0;
+  font-family: 'Roboto', sans-serif;
+  font-size:80%;
+  font-weight:400;
+  text-align:right;
+}
+/*----------------------------------------------------------------------------*/
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
 /* Question Index */
 .outerframe.withindex,.withindex .outerframe{
 }
 .allinone .withindex{margin:0}
 
 #index {
-	height: 100%;
-	clear: both;
+  height: 100%;
+  clear: both;
   padding:20px 15px;
   background: #f8f8f8;
   border-top: 1px solid #dfded5;
@@ -2103,158 +2103,197 @@ padding-left: 0;
 #index .container .row.missing { background: #bc3d34; color: #fff; }
 #index .container input {width: 100%; margin: 10px 0;}
 /*----------------------------------------------------------------------------*/
-  
-  
-  
-  
-  
-  /*----------------------------------------------------------------------------*/
-  /* taken from default template */
-  /* Tips / Validation Messages */
-  /* If the question is invalid, but has not been submitted, give it a pleasant warning color */
-  div.em_num_answers.good {
-    color: green;
-  }
-  
-  div.em_num_answers.error {
-    color: red;
-    display: block;
-  }
-  
-  div.em_value_range.good {
-    color: green;
-  }
-  div.em_value_range.error {
-    color: red;
-    display: block;
-  }
-  
-  div.em_sum_range.good {
-    color: green;
-  }
-  div.em_sum_range.error {
-    color: red;
-    display: block;
-  }
-  
-  div.em_regex_validation {
-    display: none;
-  }
-  div.em_regex_validation.good {
-    color: green;
-  }
-  div.em_regex_validation.error {
-    color: red;
-  }
-  
-  div.em_q_fn_validation.good {
-    color: green;
-  }
-  div.em_q_fn_validation.error {
-    color: red;
-  }
-  
-  div.em_sq_fn_validation.good {
-    color: green;
-  }
-  div.em_sq_fn_validation.error {
-    color: red;
-  }
-  
-  div.em_other_comment_mandatory.good {
-    display: none;
-  }
-  div.em_other_comment_mandatory.error {
-    color: red;
-    display: block;
-  }
-  
-  input.em_sq_validation.good, textarea.em_sq_validation.good {
-  }
-  
-  input.em_sq_validation.error, textarea.em_sq_validation.error {
-    color: black;
-    background-color:  pink;
-  }
-  
-  span.dynamic_sum {
-    font-weight: bold;
-  }
-  span.dynamic_sum.good {
-    color: green;
-  }
-  span.dynamic_sum.error {
-    color: red;
-  }
-  
-  span.dynamic_remaining {
-    font-weight: bold;
-  }
-  span.dyanamic_remaining.good {
-    color: green;
-  }
-  span.dynamic_remaining.error {
-    color: red;
-  }
-  
-  /* If  it is still invalid after submit, flag it in red */
-  .input-error div.error {
-    color: red;
-    display: block;
-  }
-  
-  span.hide-tip div.good {
-    display: none;
-  }
-  
-  span.hide-tip div.error {
-    color: red;
-  }
-  
-  .input-error span.hide-tip div.error {
-    color: red;
-    display: block;
-  }
-  
-  /* II / 3b. Limesurvey 1.91 validation styles					*/
-  p.good
-    {
-    color: green;
-  }
-  
-  p.problem
-    {
-    color: red;
-  }
-  
-  /*----------------------------------------------------------------------------*/
-  
-  
-  
-  
-  
-  /* START: Clearfix */
-  .clearfix:after {
-    content:"."; 
-    display:block; 
-    height:0; 
-    clear:both; 
-    visibility:hidden;
-  }
-  .clearfix {display:inline-block;}
-  /* Hides from IE-mac \*/
-  * html .clearfix {height:1%;}
-  .clearfix {display:block;}
-  /* End hide from IE-mac */
-  /* END: Clearfix */
-  
+
+
+
+
+
+/*----------------------------------------------------------------------------*/
+/* taken from default template */
+/* Tips / Validation Messages */
+/* If the question is invalid, but has not been submitted, give it a pleasant warning color */
+div.em_num_answers.good {
+  color: green;
+}
+
+div.em_num_answers.error {
+  color: red;
+  display: block;
+}
+
+div.em_value_range.good {
+  color: green;
+}
+div.em_value_range.error {
+  color: red;
+  display: block;
+}
+
+div.em_sum_range.good {
+  color: green;
+}
+div.em_sum_range.error {
+  color: red;
+  display: block;
+}
+
+div.em_regex_validation {
+  display: none;
+}
+div.em_regex_validation.good {
+  color: green;
+}
+div.em_regex_validation.error {
+  color: red;
+}
+
+div.em_q_fn_validation.good {
+  color: green;
+}
+div.em_q_fn_validation.error {
+  color: red;
+}
+
+div.em_sq_fn_validation.good {
+  color: green;
+}
+div.em_sq_fn_validation.error {
+  color: red;
+}
+
+div.em_other_comment_mandatory.good {
+  display: none;
+}
+div.em_other_comment_mandatory.error {
+  color: red;
+  display: block;
+}
+
+input.em_sq_validation.good, textarea.em_sq_validation.good {
+}
+
+input.em_sq_validation.error, textarea.em_sq_validation.error {
+  color: black;
+  background-color:  pink;
+}
+
+span.dynamic_sum {
+  font-weight: bold;
+}
+span.dynamic_sum.good {
+  color: green;
+}
+span.dynamic_sum.error {
+  color: red;
+}
+
+span.dynamic_remaining {
+  font-weight: bold;
+}
+span.dyanamic_remaining.good {
+  color: green;
+}
+span.dynamic_remaining.error {
+  color: red;
+}
+
+/* If  it is still invalid after submit, flag it in red */
+.input-error div.error {
+  color: red;
+  display: block;
+}
+
+span.hide-tip div.good {
+  display: none;
+}
+
+span.hide-tip div.error {
+  color: red;
+}
+
+.input-error span.hide-tip div.error {
+  color: red;
+  display: block;
+}
+
+/* II / 3b. Limesurvey 1.91 validation styles					*/
+p.good
+{
+  color: green;
+}
+
+p.problem
+{
+  color: red;
+}
+
+/*----------------------------------------------------------------------------*/
+
+
+
+
+
+/* START: Clearfix */
+.clearfix:after {
+  content:".";
+  display:block;
+  height:0;
+  clear:both;
+  visibility:hidden;
+}
+.clearfix {display:inline-block;}
+/* Hides from IE-mac \*/
+* html .clearfix {height:1%;}
+.clearfix {display:block;}
+/* End hide from IE-mac */
+/* END: Clearfix */
+
 
 /* Mobile */
 
 .numeric-multi .answer ul li label, .multiple-opt-comments .answer ul li span.option, .multiple-opt-comments .answer ul li span.comment, .multiple-short-txt .answer ul li label, .multiple-short-txt .answer ul li span {
-	display: block;
+  display: block;
 }
 
 .multiple-short-txt .answer ul li span {
-	margin: 0 0 15px 0;
-}                                                                                                                                
+  margin: 0 0 15px 0;
+}
+
+.b-Date{
+  background-color:#e8e8e8;
+  font-size: 0.9em;
+  margin-left: 10px;
+  padding: 6px;
+  margin-top: 10px;
+  display:inline-block;
+  text-transform: lowercase;
+}
+.full-date{
+  display:none!important;
+}
+@media screen and (max-width:736px){
+  .b-Date{
+    background-color:#e8e8e8;
+    font-size: 0.9em;
+    margin-left: 10px;
+    padding: 6px;
+    margin-top: 10px;
+    display:inline-block;
+    text-transform: lowercase;
+  }
+  .mobile-date{
+    display:block;
+  }
+
+}
+@media screen and (max-width: 360px ){
+  .b-Date{
+    margin-left:0px
+  }
+  .mobile-date{
+    display:block;
+  }
+  .full-date{
+    display:none;
+  }
+}


### PR DESCRIPTION
QUESTION: make date formatting on date picker more universal... currently it is day, month, year change to  year, month, day  (e.g. 2015-01-08) & use dashes and not decimal points. ANSWER: You can change date format in lime survey for all survey and for every question. For all survey: Date/Time format when you create or adit survey.For question: Show advanced settings->Date/Time format. But this changes is only for view. Date stored to database in format YYYY-MM-DD.

QUESTION: Selecting a date is difficult on a mobile phone.  Could we cahnge this to 3 dropdown menus (Year) (Month) (Day)  all numbers (From curent year minus 100 years [1915] to current year [2015] -- so it is dynamic), Months 1 - 12, days 1 - 31. ANSWER: We make  3 dropdown menus (Year) (Month) (Day) for mobiles and Ipad. 

Test by Me and Alex usinf PC (Chrome, Firefox), Iphone5(safari),  Ipad air(safari), anrroid (chrome) 