### PR TITLE
#88564418: token field for all export files

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1847,7 +1847,7 @@ function createFieldMap($surveyid, $style='short', $force_refresh=false, $questi
     //Check for any additional fields for this survey and create necessary fields (token and datestamp and ipaddr)
     $prow = Survey::model()->findByPk($surveyid)->getAttributes(); //Checked
 
-    if ($prow['anonymized'] == "N" && Survey::model()->hasTokens($surveyid)) {
+    if ($prow['anonymized'] == "N") {
         $fieldmap["token"]=array("fieldname"=>"token", 'sid'=>$surveyid, 'type'=>"token", "gid"=>"", "qid"=>"", "aid"=>"");
         if ($style == "full")
         {


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/822241/stories/88564418

Small fix to make `token` field displayed for all surveys on export results pages. To fix it you have to go to some active survey page (token shouldn't be activated for that survey), then to "Responces and Statistics" -> "Export results to application" (url will look like `http://localhost/projects/lime/index.php/admin/export/sa/exportresults/surveyid/:surveyId`, when :surveyId is your survey ID), and check the token option in "Choose columns" selectbox.